### PR TITLE
Fixed some bugs in the newest version.

### DIFF
--- a/pydoc_markdown/__init__.py
+++ b/pydoc_markdown/__init__.py
@@ -136,7 +136,7 @@ def write_class_member(md, value, name):
     prefix = ''
     for tpe in special_member_types:
         if isinstance(value, tpe):
-            prefix = type_.__name__
+            prefix = tpe.__name__
             break
     if hasattr(value, '__isabstractmethod__'):
         prefix = ('abstract ' + prefix).strip()

--- a/pydoc_markdown/markdown.py
+++ b/pydoc_markdown/markdown.py
@@ -37,7 +37,7 @@ class StripTrailingWhitespaceWriter(object):
             # Consume until the next newline and append it to the buffer.
             idx = text.find('\n')
             if idx > 0:
-                consume, text = text[idx+1:], text[:idx+1]
+                consume, text = text[:idx+1], text[idx+1:]
             else:
                 consume, text = text, ''
             self.buffer += consume


### PR DESCRIPTION
I found this module yesterday. It works pretty well with mkdocs.

When trying to custom prefix of member functions using the latest version, I found it hanged due to infinite loop in buffer of write().

After fixing write(), I found it failed to write selenium.webdriver's member functions. So I tried to modify variable name of the iterator and it works.