### PR TITLE
README: fix link to MkDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Pydocmd uses [MkDocs] and extended [Markdown] syntax to generate beautiful
 Python API documentation.
 
-  [MkDocs]: www.mkdocs.org/
+  [MkDocs]: http://www.mkdocs.org/
   [Markdown]: https://pythonhosted.org/Markdown/
   [Extension API]: https://niklasrosenstein.github.io/pydoc-markdown/extensions/loader/
   [Keras]: https://keras.io/


### PR DESCRIPTION
The link doesn't work on github without the `http://`