### PR TITLE
reStructuredText Preprocessor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ dist/
 README.rst
 Pipfile
 Pipfile.lock
+.idea
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Pydocmd uses [MkDocs] and extended [Markdown] syntax to generate beautiful
 Python API documentation.
 
   [MkDocs]: http://www.mkdocs.org/
-  [Markdown]: https://pythonhosted.org/Markdown/
+  [Markdown]: https://python-markdown.github.io/
   [Extension API]: https://niklasrosenstein.github.io/pydoc-markdown/extensions/loader/
   [Keras]: https://keras.io/
 

--- a/pydocmd/__main__.py
+++ b/pydocmd/__main__.py
@@ -19,8 +19,8 @@
 # THE SOFTWARE.
 
 from __future__ import print_function
-from pydocmd.document import Index
-from pydocmd.imp import import_object, dir_object
+from .document import Index
+from .imp import import_object, dir_object
 from argparse import ArgumentParser
 
 import atexit
@@ -168,8 +168,8 @@ def main():
         modspecs.append(value)
     args.subargs = modspecs
 
-  loader = import_object(config['loader'])()
-  preproc = import_object(config['preprocessor'])()
+  loader = import_object(config['loader'])(config)
+  preproc = import_object(config['preprocessor'])(config)
 
   if args.command != 'simple':
     copy_source_files(config)

--- a/pydocmd/__main__.py
+++ b/pydocmd/__main__.py
@@ -19,8 +19,8 @@
 # THE SOFTWARE.
 
 from __future__ import print_function
-from .document import Index
-from .imp import import_object, dir_object
+from pydocmd.document import Index
+from pydocmd.imp import import_object, dir_object
 from argparse import ArgumentParser
 
 import atexit
@@ -168,8 +168,8 @@ def main():
         modspecs.append(value)
     args.subargs = modspecs
 
-  loader = import_object(config['loader'])(config)
-  preproc = import_object(config['preprocessor'])(config)
+  loader = import_object(config['loader'])()
+  preproc = import_object(config['preprocessor'])()
 
   if args.command != 'simple':
     copy_source_files(config)
@@ -259,3 +259,7 @@ def main():
     return subprocess.call(args)
   except KeyboardInterrupt:
     return signal.SIGINT
+
+
+if __name__ == '__main__':
+  main()

--- a/pydocmd/loader.py
+++ b/pydocmd/loader.py
@@ -25,7 +25,6 @@ that name, but is not supposed to apply preprocessing.
 """
 
 from __future__ import print_function
-from .document import Section
 from .imp import import_object_with_scope
 import inspect
 import types
@@ -61,10 +60,8 @@ class PythonLoader(object):
   Expects absolute identifiers to import with #import_object_with_scope().
   """
 
-  def __init__(self, config):
-    self.config = config
-
-  def load_section(self, section):
+  @staticmethod
+  def load_section(section):
     """
     Loads the contents of a #Section. The `section.identifier` is the name
     of the object that we need to load.
@@ -94,7 +91,7 @@ class PythonLoader(object):
 
 
 def get_docstring(function):
-  if hasattr(function, '__name__'):
+  if hasattr(function, '__name__') or isinstance(function, property):
     return function.__doc__ or ''
   else:
     return function.__call__.__doc__ or ''

--- a/pydocmd/loader.py
+++ b/pydocmd/loader.py
@@ -59,9 +59,10 @@ class PythonLoader(object):
   """
   Expects absolute identifiers to import with #import_object_with_scope().
   """
+  def __init__(self, config):
+    self.config = config
 
-  @staticmethod
-  def load_section(section):
+  def load_section(self, section):
     """
     Loads the contents of a #Section. The `section.identifier` is the name
     of the object that we need to load.

--- a/pydocmd/preprocessor.py
+++ b/pydocmd/preprocessor.py
@@ -30,11 +30,13 @@ class Preprocessor(object):
   This class implements the basic preprocessing.
   """
 
+  def __init__(self, config):
+    self.config = config
+    
   def preprocess_section(self, section):
     """
     Preprocess the contents of *section*.
     """
-
     lines = []
     codeblock_opened = False
     current_section = None

--- a/pydocmd/preprocessor.py
+++ b/pydocmd/preprocessor.py
@@ -30,9 +30,6 @@ class Preprocessor(object):
   This class implements the basic preprocessing.
   """
 
-  def __init__(self, config):
-    self.config = config
-
   def preprocess_section(self, section):
     """
     Preprocess the contents of *section*.

--- a/pydocmd/restructuredtext.py
+++ b/pydocmd/restructuredtext.py
@@ -25,10 +25,13 @@ it to fully markdown compatible markup.
 import re
 
 
-class Preprocessor(object):
+class Preprocessor:
   """
   This class implements the preprocessor for restructured text.
   """
+  def __init__(self, config):
+    self.config = config
+
   def preprocess_section(self, section):
     """
     Preprocessors a given section into it's components.
@@ -43,44 +46,41 @@ class Preprocessor(object):
       if line.startswith("```"):
         in_codeblock = not in_codeblock
 
-      if in_codeblock:
-        lines.append(line)
-        continue
+      if not in_codeblock:
+        match = re.match(r':(?:param|parameter)\s+(\w+)\s*:(.*)?$', line)
+        if match:
+          keyword = 'Arguments'
+          param = match.group(1)
+          text = match.group(2)
+          text = text.strip()
 
-      match = re.match(r':(?:param|parameter)\s+(\w+):(.*)$', line)
-      if match:
-        keyword = 'Arguments'
-        param = match.group(1)
-        text = match.group(2)
-        text = text.strip()
+          component = components.get(keyword, [])
+          component.append('- `{}`: {}'.format(param, text))
+          components[keyword] = component
+          continue
 
-        component = components.get(keyword, [])
-        component.append('- `{}`: {}'.format(param, text))
-        components[keyword] = component
-        continue
+        match = re.match(r':(?:return|returns)\s*:(.*)?$', line)
+        if match:
+          keyword = 'Returns'
+          text = match.group(1)
+          text = text.strip()
 
-      match = re.match(r':(?:return|returns):\s+(.*)$', line)
-      if match:
-        keyword = 'Returns'
-        text = match.group(1)
-        text = text.strip()
+          component = components.get(keyword, [])
+          component.append(text)
+          components[keyword] = component
+          continue
 
-        component = components.get(keyword, [])
-        component.append(text)
-        components[keyword] = component
-        continue
+        match = re.match(':(?:raises|raise)\s+(\w+)\s*:(.*)?$', line)
+        if match:
+          keyword = 'Raises'
+          exception = match.group(1)
+          text = match.group(2)
+          text = text.strip()
 
-      match = re.match(':(?:raises|raise)\s+(\w+):(.*)$', line)
-      if match:
-        keyword = 'Raises'
-        exception = match.group(1)
-        text = match.group(2)
-        text = text.strip()
-
-        component = components.get(keyword, [])
-        component.append('- `{}`: {}'.format(exception, text))
-        components[keyword] = component
-        continue
+          component = components.get(keyword, [])
+          component.append('- `{}`: {}'.format(exception, text))
+          components[keyword] = component
+          continue
 
       if keyword is not None:
         components[keyword].append(line)

--- a/pydocmd/restructuredtext.py
+++ b/pydocmd/restructuredtext.py
@@ -29,8 +29,6 @@ class Preprocessor(object):
   """
   This class implements the preprocessor for restructured text.
   """
-  _SECTION_MAP = {'param': 'Arguments', 'return': 'Returns', 'raises': 'Raises'}
-
   def preprocess_section(self, section):
     """
     Preprocessors a given section into it's components.
@@ -49,11 +47,11 @@ class Preprocessor(object):
         lines.append(line)
         continue
 
-      match = re.match(r':(param)\s+(\w+):(.*)$', line)
+      match = re.match(r':(?:param|parameter)\s+(\w+):(.*)$', line)
       if match:
-        keyword = match.group(1)
-        param = match.group(2)
-        text = match.group(3)
+        keyword = 'Arguments'
+        param = match.group(1)
+        text = match.group(2)
         text = text.strip()
 
         component = components.get(keyword, [])
@@ -61,10 +59,10 @@ class Preprocessor(object):
         components[keyword] = component
         continue
 
-      match = re.match(r':(return):\s+(.*)$', line)
+      match = re.match(r':(?:return|returns):\s+(.*)$', line)
       if match:
-        keyword = match.group(1)
-        text = match.group(2)
+        keyword = 'Returns'
+        text = match.group(1)
         text = text.strip()
 
         component = components.get(keyword, [])
@@ -72,15 +70,15 @@ class Preprocessor(object):
         components[keyword] = component
         continue
 
-      match = re.match(':(raises)\s+(\w+):(.*)$', line)
+      match = re.match(':(?:raises|raise)\s+(\w+):(.*)$', line)
       if match:
-        keyword = match.group(1)
-        param = match.group(2)
-        text = match.group(3)
+        keyword = 'Raises'
+        exception = match.group(1)
+        text = match.group(2)
         text = text.strip()
 
         component = components.get(keyword, [])
-        component.append('- `{}`: {}'.format(param, text))
+        component.append('- `{}`: {}'.format(exception, text))
         components[keyword] = component
         continue
 
@@ -89,12 +87,13 @@ class Preprocessor(object):
       else:
         lines.append(line)
 
-    for component in ['param', 'return', 'raises']:
-      self._append_section(lines, component, components)
+    for key in components:
+      self._append_section(lines, key, components)
 
     section.content = '\n'.join(lines)
 
-  def _append_section(self, lines, key, sections):
+  @staticmethod
+  def _append_section(lines, key, sections):
     section = sections.get(key)
     if not section:
       return
@@ -102,5 +101,5 @@ class Preprocessor(object):
     if lines and lines[-1]:
       lines.append('')
 
-    lines.extend(['**{}**:'.format(self._SECTION_MAP[key]), ''])  # add an extra line because of markdown syntax
+    lines.extend(['**{}**:'.format(key), ''])  # add an extra line because of markdown syntax
     lines.extend(section)

--- a/pydocmd/restructuredtext.py
+++ b/pydocmd/restructuredtext.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2017  Niklas Rosenstein
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+This module implements preprocessing Markdown-like docstrings and converts
+it to fully markdown compatible markup.
+"""
+
+import re
+
+
+class Preprocessor(object):
+  """
+  This class implements the preprocessor for restructured text.
+  """
+  _SECTION_MAP = {'param': 'Arguments', 'return': 'Returns', 'raises': 'Raises'}
+
+  def preprocess_section(self, section):
+    """
+    Preprocessors a given section into it's components.
+    """
+    lines = []
+    in_codeblock = False
+    keyword = None
+    components = {}
+    for line in section.content.split('\n'):
+      line = line.strip()
+
+      if line.startswith("```"):
+        in_codeblock = not in_codeblock
+
+      if in_codeblock:
+        lines.append(line)
+        continue
+
+      match = re.match(r':(param)\s+(\w+):(.*)$', line)
+      if match:
+        keyword = match.group(1)
+        param = match.group(2)
+        text = match.group(3)
+        text = text.strip()
+
+        component = components.get(keyword, [])
+        component.append('- `{}`: {}'.format(param, text))
+        components[keyword] = component
+        continue
+
+      match = re.match(r':(return):\s+(.*)$', line)
+      if match:
+        keyword = match.group(1)
+        text = match.group(2)
+        text = text.strip()
+
+        component = components.get(keyword, [])
+        component.append(text)
+        components[keyword] = component
+        continue
+
+      match = re.match(':(raises)\s+(\w+):(.*)$', line)
+      if match:
+        keyword = match.group(1)
+        param = match.group(2)
+        text = match.group(3)
+        text = text.strip()
+
+        component = components.get(keyword, [])
+        component.append('- `{}`: {}'.format(param, text))
+        components[keyword] = component
+        continue
+
+      if keyword is not None:
+        components[keyword].append(line)
+      else:
+        lines.append(line)
+
+    for component in ['param', 'return', 'raises']:
+      self._append_section(lines, component, components)
+
+    section.content = '\n'.join(lines)
+
+  def _append_section(self, lines, key, sections):
+    section = sections.get(key)
+    if not section:
+      return
+
+    if lines and lines[-1]:
+      lines.append('')
+
+    lines.extend(['**{}**:'.format(self._SECTION_MAP[key]), ''])  # add an extra line because of markdown syntax
+    lines.extend(section)

--- a/tests/test_restructuredtext.py
+++ b/tests/test_restructuredtext.py
@@ -1,0 +1,55 @@
+import pytest
+
+from pydocmd.document import Section
+from pydocmd.restructuredtext import Preprocessor
+
+
+@pytest.fixture
+def preprocessor():
+  return Preprocessor()
+
+
+@pytest.fixture
+def section():
+  return Section(None)
+
+
+def test_preprocess_section(preprocessor, section):
+  section.content = '\n'.join([
+    '```',
+    'Param(foo, foo=bar)',
+    '```',
+    'This is the main documentation!',
+    '',
+    ' :param line1: The docs for line1',
+    ':param line2: This docs for',
+    'line2',
+    ':return: This return',
+    'can be multi-line!',
+    ':raises ValueError: If something bad happens!'
+  ])
+
+  expected = '\n'.join([
+    '```',
+    'Param(foo, foo=bar)',
+    '```',
+    'This is the main documentation!',
+    '',
+    '**Arguments**:',
+    '',
+    '- `line1`: The docs for line1',
+    '- `line2`: This docs for',
+    'line2',
+    '',
+    '**Returns**:',
+    '',
+    'This return',
+    'can be multi-line!',
+    '',
+    '**Raises**:',
+    '',
+    '- `ValueError`: If something bad happens!'
+  ])
+
+  preprocessor.preprocess_section(section)
+  assert section.content == expected


### PR DESCRIPTION
This PR implements the reStructuredText preprocessor!

Additions:
- A `if __name__ == '__main__'` check so that I could run `__main__.py` directly.
- A property check so that compiling your documentation didn't throw an error
- The reStructuredText preprocessor. `:param`, `:return`, `:raises` and their aliases are supported. I plan to implement`:rtype`, `:type` and potentially others.
- A fairly simple test using pytest.
- Fixed broken link in README