### PR TITLE
Add option to use markdown headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ theme:    readthedocs
 loader:   pydocmd.loader.PythonLoader
 preprocessor: pydocmd.preprocessor.Preprocessor
 
+# Whether to output headers as markdown or HTML.  Used to workaround
+# https://github.com/NiklasRosenstein/pydoc-markdown/issues/11.  The default is
+# to generate HTML with unique and meaningful id tags, which can't be done with
+# markdown.
+headers: html
+
 # Additional search path for your Python module. If you use Pydocmd from a
 # subdirectory of your project (eg. docs/), you may want to add the parent
 # directory here.

--- a/pydocmd/__main__.py
+++ b/pydocmd/__main__.py
@@ -52,6 +52,7 @@ def default_config(config):
   config.setdefault('docs_dir', 'sources')
   config.setdefault('gens_dir', '_build/pydocmd')
   config.setdefault('site_dir', '_build/site')
+  config.setdefault('headers', 'html')
   config.setdefault('theme', 'readthedocs')
   config.setdefault('loader', 'pydocmd.loader.PythonLoader')
   config.setdefault('preprocessor', 'pydocmd.preprocessor.Preprocessor')
@@ -200,7 +201,7 @@ def main():
       def create_sections(name, level):
         if level > expand_depth:
           return
-        index.new_section(doc, name, depth=depth + level)
+        index.new_section(doc, name, depth=depth + level, header_type=config.get('headers', 'html'))
         sort_order = config.get('sort')
         if sort_order not in ('line', 'name'):
           sort_order = 'line'

--- a/pydocmd/document.py
+++ b/pydocmd/document.py
@@ -57,9 +57,7 @@ class Section(object):
     Render the section into *stream*.
     """
 
-    print('<h{depth} id="{id}">{title}</h{depth}>\n'
-      .format(depth = self.depth, id = self.identifier, title = self.title),
-      file = stream)
+    print('#' * self.depth, self.title, file = stream)
     print(self.content, file=stream)
 
   @property

--- a/pydocmd/document.py
+++ b/pydocmd/document.py
@@ -45,19 +45,27 @@ class Section(object):
   content (str): The Markdown-formatted content of the section.
   """
 
-  def __init__(self, doc, identifier=None, title=None, depth=1, content=None):
+  def __init__(self, doc, identifier=None, title=None, depth=1, content=None, header_type='html'):
     self.doc = doc
     self.identifier = identifier
     self.title = title
     self.depth = depth
     self.content = content if content is not None else '*Nothing to see here.*'
+    self.header_type = header_type
 
   def render(self, stream):
     """
     Render the section into *stream*.
     """
 
-    print('#' * self.depth, self.title, file = stream)
+    if self.header_type == 'html':
+      print('<h{depth} id="{id}">{title}</h{depth}>\n'
+        .format(depth = self.depth, id = self.identifier, title = self.title),
+        file = stream)
+    elif self.header_type == 'markdown':
+      print('#' * self.depth, self.title, file = stream)
+    else:
+      raise ValueError('Invalid header type: %s' % self.header_type)
     print(self.content, file=stream)
 
   @property

--- a/tests/test_markdown_headers.py
+++ b/tests/test_markdown_headers.py
@@ -1,0 +1,28 @@
+import pytest
+import io
+
+from pydocmd.document import Section
+
+@pytest.fixture
+def section():
+  return Section(None)
+
+def test_preprocess_section(section):
+  section.depth = 1
+  section.title = 'My Header'
+  section.content = 'content'
+  section.identifier = 'section-identifier'
+
+  html_header_buffer = io.StringIO()
+  section.render(html_header_buffer)
+  assert html_header_buffer.getvalue() == "<h1 id=\"section-identifier\">My Header</h1>\n\ncontent\n"
+
+  section.header_type = 'markdown'
+  markdown_header_buffer = io.StringIO()
+  section.render(markdown_header_buffer)
+  assert markdown_header_buffer.getvalue() == "# My Header\ncontent\n"
+
+  with pytest.raises(ValueError,
+                     message="Expected exception on invalid header type"):
+    section.header_type = 'invalid'
+    section.render(markdown_header_buffer)


### PR DESCRIPTION
This reverts the functionality back to before these headers were added as HTML.  The upside is that https://github.com/NiklasRosenstein/pydoc-markdown/issues/11 no longer causes generated sections to not have a table of contents, but the downside is we don't get the unique header id tags which was the goal of the change in the first place.

Thanks for this library by the way @NiklasRosenstein, very useful!  Let me know if I'm missing something with this change or if you see a better way.