### PR TITLE
markdown headers if simple

### DIFF
--- a/pydocmd/__main__.py
+++ b/pydocmd/__main__.py
@@ -49,10 +49,14 @@ def read_config():
 
 
 def default_config(config):
+  args = parser.parse_args()
   config.setdefault('docs_dir', 'sources')
   config.setdefault('gens_dir', '_build/pydocmd')
   config.setdefault('site_dir', '_build/site')
-  config.setdefault('headers', 'markdown')
+  if args.command == 'simple':
+      config.setdefault('headers', 'markdown')
+  else:
+      config.setdefault('headers', 'html')
   config.setdefault('theme', 'readthedocs')
   config.setdefault('loader', 'pydocmd.loader.PythonLoader')
   config.setdefault('preprocessor', 'pydocmd.preprocessor.Preprocessor')

--- a/pydocmd/__main__.py
+++ b/pydocmd/__main__.py
@@ -52,7 +52,7 @@ def default_config(config):
   config.setdefault('docs_dir', 'sources')
   config.setdefault('gens_dir', '_build/pydocmd')
   config.setdefault('site_dir', '_build/site')
-  config.setdefault('headers', 'html')
+  config.setdefault('headers', 'markdown')
   config.setdefault('theme', 'readthedocs')
   config.setdefault('loader', 'pydocmd.loader.PythonLoader')
   config.setdefault('preprocessor', 'pydocmd.preprocessor.Preprocessor')


### PR DESCRIPTION
This makes markdown headers default when the code is used in "simple" mode. 

I personally find this useful, but I haven't explored the code extensively, so feel free to ignore this pull request if I'm missing something obvious.

Thanks for this code, I think it's great!