### PR TITLE
Tweaks and fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ Pipfile
 Pipfile.lock
 .idea
 .pytest_cache/
+
+# Direnv config
+.direnv
+.envrc

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ generate:
 # MkDocs pages configuration. The `<<` operator is sugar added by pydocmd
 # that allows you to use an external Markdown file (eg. your project's README)
 # in the documentation. The path must be relative to current working directory.
+# This configuration is not mandatory if you have your own mkdocs.yml config file.
 pages:
 - Home: index.md << ../README.md
 - foobar.baz:

--- a/pydocmd/__main__.py
+++ b/pydocmd/__main__.py
@@ -74,7 +74,11 @@ def write_temp_mkdocs_config(inconf):
   config['docs_dir'] = inconf['gens_dir']
   for key in ('markdown_extensions', 'pages', 'repo_url'):
     if key in inconf:
-      config[key] = inconf[key]
+
+      if key == 'pages':
+        config['nav'] = inconf[key]
+      else:
+        config[key] = inconf[key]
 
   with open('mkdocs.yml', 'w') as fp:
     yaml.dump(config, fp)

--- a/pydocmd/__main__.py
+++ b/pydocmd/__main__.py
@@ -54,9 +54,9 @@ def default_config(config):
   config.setdefault('gens_dir', '_build/pydocmd')
   config.setdefault('site_dir', '_build/site')
   if args.command == 'simple':
-      config.setdefault('headers', 'markdown')
+    config.setdefault('headers', 'markdown')
   else:
-      config.setdefault('headers', 'html')
+    config.setdefault('headers', 'html')
   config.setdefault('theme', 'readthedocs')
   config.setdefault('loader', 'pydocmd.loader.PythonLoader')
   config.setdefault('preprocessor', 'pydocmd.preprocessor.Preprocessor')
@@ -91,7 +91,24 @@ def makedirs(path):
     os.makedirs(path)
 
 
-def copy_source_files(config):
+# Also process all pages to copy files outside of the docs_dir to the gens_dir.
+def process_pages(data, gens_dir):
+  for key in data:
+    filename = data[key]
+    if isinstance(filename, str) and '<<' in filename:
+      filename, source = filename.split('<<')
+      filename, source = filename.rstrip(), source.lstrip()
+      outfile = os.path.join(gens_dir, filename)
+      makedirs(os.path.dirname(outfile))
+      shutil.copyfile(source, outfile)
+      data[key] = filename
+    elif isinstance(filename, dict):
+      process_pages(filename, gens_dir)
+    elif isinstance(filename, list):
+      [process_pages(x, gens_dir) for x in filename]
+
+
+def copy_source_files(config, pages_required=True):
   """
   Copies all files from the `docs_dir` to the `gens_dir` defined in the
   *config*. It also takes the MkDocs `pages` configuration into account
@@ -113,24 +130,14 @@ def copy_source_files(config):
       makedirs(os.path.dirname(dest_fname))
       shutil.copyfile(os.path.join(root, fname), dest_fname)
 
-  # Also process all pages to copy files outside of the docs_dir
-  # to the gens_dir.
-  def process_pages(data):
-    for key in data:
-      filename = data[key]
-      if isinstance(filename, str) and '<<' in filename:
-        filename, source = filename.split('<<')
-        filename, source = filename.rstrip(), source.lstrip()
-        outfile = os.path.join(config['gens_dir'], filename)
-        makedirs(os.path.dirname(outfile))
-        shutil.copyfile(source, outfile)
-        data[key] = filename
-      elif isinstance(filename, dict):
-        process_pages(filename)
-      elif isinstance(filename, list):
-        [process_pages(x) for x in filename]
+  if 'pages' not in config:
+    if pages_required:
+      raise RuntimeError('pydocmd.yml does not have defined pages!')
+
+    return
+
   for page in config['pages']:
-    process_pages(page)
+    process_pages(page, config['gens_dir'])
 
 
 def new_project():
@@ -177,10 +184,10 @@ def main():
   preproc = import_object(config['preprocessor'])(config)
 
   if args.command != 'simple':
-    copy_source_files(config)
+    mkdocs_exist = os.path.isfile('mkdocs.yml')
+    copy_source_files(config, pages_required=not mkdocs_exist)
 
-    # Generate MkDocs configuration if it doesn't exist.
-    if not os.path.isfile('mkdocs.yml'):
+    if not mkdocs_exist:
       log('Generating temporary MkDocs config...')
       write_temp_mkdocs_config(config)
 

--- a/pydocmd/imp.py
+++ b/pydocmd/imp.py
@@ -66,9 +66,15 @@ def import_object_with_scope(name):
   for part in parts[1:]:
     current_name += '.' + part
     try:
-      sub_obj = getattr(obj, part)
+      if '__dict__' in obj:
+        # Using directly __dict__ for descriptors, where we want to get the descriptor's instance
+        # and not calling the descriptor's __get__ method.
+        sub_obj = obj.__dict__[part]
+      else:
+        sub_obj = getattr(obj, part)
+
       scope, obj = obj, sub_obj
-    except AttributeError:
+    except (AttributeError, KeyError):
       try:
         obj = scope = import_module(current_name)
       except ImportError as exc:

--- a/pydocmd/loader.py
+++ b/pydocmd/loader.py
@@ -92,7 +92,9 @@ class PythonLoader(object):
 
 
 def get_docstring(function):
-  if hasattr(function, '__name__') or isinstance(function, property):
+  if isinstance(function, (staticmethod, classmethod)):
+    return function.__func__.__doc__ or ''
+  elif hasattr(function, '__name__') or isinstance(function, property):
     return function.__doc__ or ''
   elif hasattr(function, '__call__'):
     return function.__call__.__doc__ or ''

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setuptools.setup(
     keywords = 'markdown pydoc generator docs documentation',
     packages = ['pydocmd'],
     install_requires = [
-        'MkDocs>=0.16.0',
+        'MkDocs>=1.0.0',
         'Markdown>=2.6.11',
         'PyYAML>=3.12',
         'six>=0.11.0',


### PR DESCRIPTION
The changes were quite minor so I was a bit lazy to create PR for each of them, if it is problem I can edit it.

Fixing #61 - for backward compatibility, I kept the original value in `pydocmd.yml` as `pages`, but the temporary configuration is generated with `nav` option. Also, I have bumped the version of the dependency to >=1.0.0 as that was the point when `nav` was introduced.

Fixing #62 - descriptors support.

Fixing #63 - if there is custom `mkdocs.yml` present the `pages` configuration in `pydocmd.yml` is not required.