### PR TITLE
Add newline before titles for plaintext readability

### DIFF
--- a/pydocmd/document.py
+++ b/pydocmd/document.py
@@ -63,7 +63,7 @@ class Section(object):
         .format(depth = self.depth, id = self.identifier, title = self.title),
         file = stream)
     elif self.header_type == 'markdown':
-      print('#' * self.depth, self.title, file = stream)
+      print('\n' + ('#' * self.depth), self.title, file = stream)
     else:
       raise ValueError('Invalid header type: %s' % self.header_type)
     print(self.content, file=stream)


### PR DESCRIPTION
This is really simple -- it just adds an additional newline preceding a title.  This doesn't affect generated HTML representations of the markdown, but makes it easier to read the plaintext markdown.

Example without change:
```
# some_func()

some description

some more description

__Returns__

`list`: a bunch of things.

# some_other_func()

other description

some more description of the other func

__Returns__

`dict`: a bunch of named things.

# such_func()

more func-y than you can imagine

unrelated text placed here by mistake

__Returns__

`OrderedDict`: a cat
```

Example with change:
```

# some_func()

some description

some more description

__Returns__

`list`: a bunch of things.


# some_other_func()

other description

some more description of the other func

__Returns__

`dict`: a bunch of named things.


# such_func()

more func-y than you can imagine

unrelated text placed here by mistake

__Returns__

`OrderedDict`: a cat
```
