### PR TITLE
Reference links (cross-reference) implementation

### DIFF
--- a/pydocmd/__main__.py
+++ b/pydocmd/__main__.py
@@ -244,6 +244,10 @@ def main():
         doc = index.new_document(fname)
         add_sections(doc, object_names)
 
+  preproc.link_lookup = {}
+  for file, doc in index.documents.items():
+    for section in doc.sections:
+      preproc.link_lookup[section.identifier] = file
   # Load the docstrings and fill the sections.
   log('Started generating documentation...')
   for doc in index.documents.values():

--- a/pydocmd/preprocessor.py
+++ b/pydocmd/preprocessor.py
@@ -39,7 +39,7 @@ class Preprocessor(object):
     """
     codeblock_opened = False
     current_section = None
-    content = self._preprocess_refs(section.content)
+    content = self._preprocess_refs(section)
     lines = []
     for line in content.split('\n'):
       if line.startswith("```"):
@@ -72,17 +72,49 @@ class Preprocessor(object):
 
     return line, current_section
 
-  def _preprocess_refs(self, content):
-    # TODO: Generate links to the referenced symbols.
+  def _preprocess_refs(self, section):
+    """
+    Parses references and replaces them with markdown links
+    Syntax is:
+        `#anchor` for in page reference
+        `#::mod[.submod][#item][+n]` where
+            `mod.submod` is the module, `item` is the module member and n is
+            the number of duplicates in case of headers: markdown conflicts.
+            You can also references class members: or `#::mod.submod.cls#method`
+    """
     def handler(match):
+      mod = match.group('mod')
       ref = match.group('ref')
       parens = match.group('parens') or ''
+      dup = match.group('dup')
       has_trailing_dot = False
       if not parens and ref.endswith('.'):
         ref = ref[:-1]
         has_trailing_dot = True
-      result = '`{}`'.format(ref + parens)
+
+      if '#' in ref:
+        text = ref.split('#')[-1]
+        title = mod_ref = ref.replace('#', '.')
+        anchor = text.lower()
+      else:
+        title = text = anchor = ref
+        anchor = ref.replace('.', '')
+        mod_ref = ref
+
+      if self.config['headers'] == 'html':
+          anchor = mod_ref
+          if not mod and not anchor.startswith(section.identifier):
+              anchor = section.identifier + '.' + anchor
+      elif dup:
+          anchor += '_' + dup[1:]
+
+      result = '`{}`'.format(text + parens)
+      link = self.link_lookup.get(mod_ref, self.link_lookup.get(ref))
+      if mod and link:
+        result = ('[' + result + '](' + link + '#' + anchor + ' "' + title + '")')
+      else:
+        result = '[' + result + '](#' + anchor + ')'
       if has_trailing_dot:
         result += '.'
       return (match.group('prefix') or '') + result
-    return re.sub('(?P<prefix>^| |\t)#(?P<ref>[\w\d\._]+)(?P<parens>\(\))?', handler, content)
+    return re.sub('(?P<prefix>^| |\t)#(?P<mod>::)?(?P<ref>[\w\d\._\#]+)(?P<parens>\(\))?(?P<dup>\+\d+)?', handler, section.content)

--- a/pydocmd/preprocessor.py
+++ b/pydocmd/preprocessor.py
@@ -80,7 +80,7 @@ class Preprocessor(object):
         `#::mod[.submod][#item][+n]` where
             `mod.submod` is the module, `item` is the module member and n is
             the number of duplicates in case of headers: markdown conflicts.
-            You can also references class members: or `#::mod.submod.cls#method`
+            You can also references class members: `#::mod.submod.cls#method`
     """
     def handler(match):
       mod = match.group('mod')

--- a/pydocmd/preprocessor.py
+++ b/pydocmd/preprocessor.py
@@ -37,10 +37,11 @@ class Preprocessor(object):
     """
     Preprocess the contents of *section*.
     """
-    lines = []
     codeblock_opened = False
     current_section = None
-    for line in section.content.split('\n'):
+    content = self._preprocess_refs(section.content)
+    lines = []
+    for line in content.split('\n'):
       if line.startswith("```"):
         codeblock_opened = (not codeblock_opened)
       if not line:
@@ -48,7 +49,7 @@ class Preprocessor(object):
       elif not codeblock_opened:
         line, current_section = self._preprocess_line(line, current_section)
       lines.append(line)
-    section.content = self._preprocess_refs('\n'.join(lines))
+    section.content = '\n'.join(lines)
 
   def _preprocess_line(self, line, current_section):
     match = re.match(r'# (.*)$', line)

--- a/pydocmd/preprocessor.py
+++ b/pydocmd/preprocessor.py
@@ -43,7 +43,9 @@ class Preprocessor(object):
     for line in section.content.split('\n'):
       if line.startswith("```"):
         codeblock_opened = (not codeblock_opened)
-      if not codeblock_opened:
+      if not line:
+        current_section = None
+      elif not codeblock_opened:
         line, current_section = self._preprocess_line(line, current_section)
       lines.append(line)
     section.content = self._preprocess_refs('\n'.join(lines))


### PR DESCRIPTION
I needed to have references in my documentation so I made a quick and dirty implementation of it.
It currently should support both headers config, html and markdown.
Syntax is:
  - `#anchor` for in page reference
  - `#::mod[.submod][#item][+n]` where `mod.submod` is the module, `item` is the module member and n is the number of duplicates in case of headers: markdown conflicts. 

You can also references class members: `#::mod.submod.cls#method`.

You can see it live here https://kozea.github.io/unrest/unrest/ from https://github.com/Kozea/unrest/blob/master/unrest/unrest.py .