### PR TITLE
Pretty print function signatures

### DIFF
--- a/pydocmd/loader.py
+++ b/pydocmd/loader.py
@@ -28,6 +28,7 @@ from __future__ import print_function
 from .imp import import_object_with_scope
 import inspect
 import types
+from yapf.yapflib.yapf_api import FormatCode
 
 function_types = (types.FunctionType, types.LambdaType, types.MethodType,
   types.BuiltinFunctionType, types.BuiltinMethodType)
@@ -88,7 +89,8 @@ class PythonLoader(object):
     # Add the function signature in a code-block.
     if callable(obj):
       sig = get_function_signature(obj, scope if inspect.isclass(scope) else None)
-      section.content = '```python\n{}\n```\n'.format(sig) + section.content
+      sig, _ = FormatCode(sig, style_config='pep8')
+      section.content = '```python\n{}\n```\n'.format(sig.strip()) + section.content
 
 
 def get_docstring(function):

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setuptools.setup(
         'Markdown>=2.6.11',
         'PyYAML>=3.12',
         'six>=0.11.0',
+        'yapf>=0.26.0',
     ],
     entry_points = dict(
         console_scripts = [


### PR DESCRIPTION
This PR auto-formats function signatures. This is makes very long function signatures a lot more readable.

## Before
```python
SeparableConv2D(filters, kernel_size, strides=(1, 1), padding='valid', data_format=None, dilation_rate=(1, 1), depth_multiplier=1, activation=None, use_bias=True, depthwise_initializer='glorot_uniform', pointwise_initializer='glorot_uniform', bias_initializer='zeros', depthwise_regularizer=None, pointwise_regularizer=None, bias_regularizer=None, activity_regularizer=None, depthwise_constraint=None, pointwise_constraint=None, bias_constraint=None, **kwargs)
```

## After
```python
SeparableConv2D(
    filters,
    kernel_size,
    strides=(1, 1),
    padding='valid',
    data_format=None,
    dilation_rate=(1, 1),
    depth_multiplier=1,
    activation=None,
    use_bias=True,
    depthwise_initializer='glorot_uniform',
    pointwise_initializer='glorot_uniform',
    bias_initializer='zeros',
    depthwise_regularizer=None,
    pointwise_regularizer=None,
    bias_regularizer=None,
    activity_regularizer=None,
    depthwise_constraint=None,
    pointwise_constraint=None,
    bias_constraint=None,
    **kwargs)
```

## Why using yapf?
- [black](https://github.com/ambv/black) doesn't yet have a stable API: https://github.com/ambv/black/issues/779
- [autopep8](https://github.com/hhatto/autopep8) had weird whitespace handling with tuple arguments