### PR TITLE
Improve handling of text indentation in the RST preprocessor

### DIFF
--- a/pydocmd/restructuredtext.py
+++ b/pydocmd/restructuredtext.py
@@ -23,7 +23,7 @@ it to fully markdown compatible markup.
 """
 
 import re
-
+import textwrap
 
 class Preprocessor(object):
   """
@@ -40,14 +40,19 @@ class Preprocessor(object):
     in_codeblock = False
     keyword = None
     components = {}
-    for line in section.content.split('\n'):
-      line = line.strip()
+
+    line = textwrap.dedent(section.content)
+
+    for line in section.content.splitlines():
+      line = line.rstrip()
 
       if line.startswith("```"):
         in_codeblock = not in_codeblock
 
-      if not in_codeblock:
-        match = re.match(r':(?:param|parameter)\s+(\w+)\s*:(.*)?$', line)
+      line_codeblock = line.startswith('    ')
+
+      if not in_codeblock and not line_codeblock:
+        match = re.match(r'\s*:(?:param|parameter)\s+(\w+)\s*:(.*)?$', line)
         if match:
           keyword = 'Arguments'
           param = match.group(1)
@@ -59,7 +64,7 @@ class Preprocessor(object):
           components[keyword] = component
           continue
 
-        match = re.match(r':(?:return|returns)\s*:(.*)?$', line)
+        match = re.match(r'\s*:(?:return|returns)\s*:(.*)?$', line)
         if match:
           keyword = 'Returns'
           text = match.group(1)
@@ -70,7 +75,7 @@ class Preprocessor(object):
           components[keyword] = component
           continue
 
-        match = re.match(':(?:raises|raise)\s+(\w+)\s*:(.*)?$', line)
+        match = re.match('\s*:(?:raises|raise)\s+(\w+)\s*:(.*)?$', line)
         if match:
           keyword = 'Raises'
           exception = match.group(1)


### PR DESCRIPTION
Instead of `strip()`ing each line this will:
 - Remove the section indentation with `textwrap.dedent()` (available in
   Python 2.3+)
 - Strip whitespace on the right-hand side of each line
 - Treat lines prefixed with four spaces as codeblocks
 - Allow RST keyword lines to be indented (up to four spaces)

The 4-space codeblock style is standard Markdown, implemented in most
(but not all) Markdown parsers.

By using `textwrap.dedent()` instead of `strip()` we are able to remove
the spaces introduced by indented comment sections while preserving
additional indentations within section.

For example, say we have the following code:

    section = """\
         a
          b
           c
    """

    print(section)
    print()

    for line in section.splitlines():
        print(line.strip())
    print()

    print(textwrap.dedent(section))
    print()

This will print:

        a
         b
          c

    a
    b
    c

    a
     b
      c