### PR TITLE
Add arg, argument keywords to reStructuredText preprocessor

### DIFF
--- a/pydocmd/preprocessors/rst.py
+++ b/pydocmd/preprocessors/rst.py
@@ -52,7 +52,7 @@ class Preprocessor(object):
       line_codeblock = line.startswith('    ')
 
       if not in_codeblock and not line_codeblock:
-        match = re.match(r'\s*:(?:param|parameter)\s+(\w+)\s*:(.*)?$', line)
+        match = re.match(r'\s*:(?:arg|argument|param|parameter)\s+(\w+)\s*:(.*)?$', line)
         if match:
           keyword = 'Arguments'
           param = match.group(1)


### PR DESCRIPTION
This PR adds two additional keywords to the reStructuredText preprocessor: `:arg:`, `:argument:`. These are used in the same way as the `:param:` and `:parameter:` keywords.

These are [official keywords supported by Sphinx](https://www.sphinx-doc.org/en/1.5/domains.html#info-field-lists), and it would be nice for pydocmd to support them too.