### PR TITLE
Source linker improvements for RTD

### DIFF
--- a/.changelog/_unreleased.yml
+++ b/.changelog/_unreleased.yml
@@ -20,3 +20,8 @@ changes:
   description: add `MarkdownRenderer.source_linker` option
   fixes:
   - '#122'
+- type: change
+  component: cli
+  description: '`-v,--verbose` and `-q,--quiet` flags are now countable (e.g. `-vv`
+    will raise the logging verbosity to `DEBUG`)'
+  fixes: []

--- a/.changelog/_unreleased.yml
+++ b/.changelog/_unreleased.yml
@@ -25,3 +25,12 @@ changes:
   description: '`-v,--verbose` and `-q,--quiet` flags are now countable (e.g. `-vv`
     will raise the logging verbosity to `DEBUG`)'
   fixes: []
+- type: improvement
+  component: internal
+  description: |
+    Ensure consistency independent of the CWD from which Pydoc-Markdown is invoked as long
+    as the same configuration file is used by introduce the `Context` object and the `init()`
+    method for plugins. The `Context.directory` is set to the parent directory of the
+    `pydoc-markdown.yml` configuration file. Plugins use that directory to interpret relative
+    paths instead of the current working directory.
+  fixes: []

--- a/.readthedocs-custom-steps.yml
+++ b/.readthedocs-custom-steps.yml
@@ -1,2 +1,2 @@
 steps:
-- pydoc-markdown --build --site-dir $SITE_DIR
+- pydoc-markdown --build --site-dir $SITE_DIR -vv

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Pydoc-Markdown is a tool and library to create Python API documentation in
 Markdown format based on `lib2to3`, allowing it to parse your Python code
 without executing it.
 
+Pydoc-Markdown requires Python 3.5 or newer.
+
 [>> Go to the Documentation](https://pydoc-markdown.readthedocs.io/en/latest/)
 
 __Features__

--- a/pydoc-markdown/package.yaml
+++ b/pydoc-markdown/package.yaml
@@ -34,7 +34,7 @@ requirements:
   - python ^3.6
   - click ^7.0
   - docspec ~0.2.0
-  - docspec-python ~0.0.4
+  - docspec-python ~0.0.6
   - nr.collections ~0.0.1
   - nr.interface ~0.0.3
   - nr.databind.core ~0.0.18

--- a/pydoc-markdown/package.yaml
+++ b/pydoc-markdown/package.yaml
@@ -34,7 +34,7 @@ requirements:
   - python ^3.5
   - click ^7.0
   - docspec ~0.2.0
-  - docspec-python ~0.0.6
+  - docspec-python ~0.0.7
   - nr.collections ~0.0.1
   - nr.interface ~0.0.3
   - nr.databind.core ~0.0.18

--- a/pydoc-markdown/package.yaml
+++ b/pydoc-markdown/package.yaml
@@ -31,7 +31,7 @@ classifiers:
   - "Programming Language :: Python :: 3.5"
 
 requirements:
-  - python ^3.6
+  - python ^3.5
   - click ^7.0
   - docspec ~0.2.0
   - docspec-python ~0.0.6

--- a/pydoc-markdown/setup.py
+++ b/pydoc-markdown/setup.py
@@ -42,7 +42,7 @@ setuptools.setup(
   install_requires = requirements,
   extras_require = {},
   tests_require = [],
-  python_requires = None, # TODO: '>=3.6,<4.0.0',
+  python_requires = None, # TODO: '>=3.5,<4.0.0',
   data_files = [],
   entry_points = {
     'console_scripts': [

--- a/pydoc-markdown/setup.py
+++ b/pydoc-markdown/setup.py
@@ -24,7 +24,7 @@ else:
   print("warning: file \"{}\" does not exist.".format(readme_file), file=sys.stderr)
   long_description = None
 
-requirements = ['click >=7.0,<8.0.0', 'docspec >=0.2.0,<0.3.0', 'docspec-python >=0.0.6,<0.1.0', 'nr.collections >=0.0.1,<0.1.0', 'nr.interface >=0.0.3,<0.1.0', 'nr.databind.core >=0.0.18,<0.1.0', 'nr.databind.json >=0.0.9,<0.1.0', 'nr.fs >=1.6.0,<2.0.0', 'requests >=2.23.0,<3.0.0', 'PyYAML >=5.3,<6.0.0', 'six >=1.11.0,<2.0.0', 'toml >=0.10.1,<1.0.0', 'watchdog >=0.10.2,<1.0.0']
+requirements = ['click >=7.0,<8.0.0', 'docspec >=0.2.0,<0.3.0', 'docspec-python >=0.0.7,<0.1.0', 'nr.collections >=0.0.1,<0.1.0', 'nr.interface >=0.0.3,<0.1.0', 'nr.databind.core >=0.0.18,<0.1.0', 'nr.databind.json >=0.0.9,<0.1.0', 'nr.fs >=1.6.0,<2.0.0', 'requests >=2.23.0,<3.0.0', 'PyYAML >=5.3,<6.0.0', 'six >=1.11.0,<2.0.0', 'toml >=0.10.1,<1.0.0', 'watchdog >=0.10.2,<1.0.0']
 
 setuptools.setup(
   name = 'pydoc-markdown',

--- a/pydoc-markdown/setup.py
+++ b/pydoc-markdown/setup.py
@@ -24,7 +24,7 @@ else:
   print("warning: file \"{}\" does not exist.".format(readme_file), file=sys.stderr)
   long_description = None
 
-requirements = ['click >=7.0,<8.0.0', 'docspec >=0.2.0,<0.3.0', 'docspec-python >=0.0.4,<0.1.0', 'nr.collections >=0.0.1,<0.1.0', 'nr.interface >=0.0.3,<0.1.0', 'nr.databind.core >=0.0.18,<0.1.0', 'nr.databind.json >=0.0.9,<0.1.0', 'nr.fs >=1.6.0,<2.0.0', 'requests >=2.23.0,<3.0.0', 'PyYAML >=5.3,<6.0.0', 'six >=1.11.0,<2.0.0', 'toml >=0.10.1,<1.0.0', 'watchdog >=0.10.2,<1.0.0']
+requirements = ['click >=7.0,<8.0.0', 'docspec >=0.2.0,<0.3.0', 'docspec-python >=0.0.6,<0.1.0', 'nr.collections >=0.0.1,<0.1.0', 'nr.interface >=0.0.3,<0.1.0', 'nr.databind.core >=0.0.18,<0.1.0', 'nr.databind.json >=0.0.9,<0.1.0', 'nr.fs >=1.6.0,<2.0.0', 'requests >=2.23.0,<3.0.0', 'PyYAML >=5.3,<6.0.0', 'six >=1.11.0,<2.0.0', 'toml >=0.10.1,<1.0.0', 'watchdog >=0.10.2,<1.0.0']
 
 setuptools.setup(
   name = 'pydoc-markdown',

--- a/pydoc-markdown/src/pydoc_markdown/contrib/renderers/markdown.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/renderers/markdown.py
@@ -21,8 +21,8 @@
 
 from docspec_python import format_arglist
 from nr.databind.core import Field, Struct
-from nr.interface import implements
-from pydoc_markdown.interfaces import Renderer, Resolver, SourceLinker
+from nr.interface import implements, override
+from pydoc_markdown.interfaces import Context, Renderer, Resolver, SourceLinker
 from typing import Iterable, List, Optional, TextIO
 import docspec
 import io
@@ -344,6 +344,7 @@ class MarkdownRenderer(Struct):
 
   # Renderer
 
+  @override
   def get_resolver(self, modules: List[docspec.Module]) -> Optional[Resolver]:
     """
     Returns a simple #Resolver implementation. Finds cross-references in the same file.
@@ -375,9 +376,17 @@ class MarkdownRenderer(Struct):
 
     return resolver
 
+  @override
   def render(self, modules: List[docspec.Module]) -> None:
     if self.filename is None:
       self._render_modules(modules, self.fp or sys.stdout)
     else:
       with io.open(self.filename, 'w', encoding=self.encoding) as fp:
         self._render_modules(modules, fp)
+
+  # PluginBase
+
+  @override
+  def init(self, context: Context) -> None:
+    if self.source_linker:
+      self.source_linker.init(context)

--- a/pydoc-markdown/src/pydoc_markdown/contrib/source_linkers/github.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/source_linkers/github.py
@@ -59,11 +59,15 @@ class GitHubSourceLinker(Struct):
     if hasattr(self, '_repo_root'):
       return self._repo_root
     self._repo_root = _getoutput(['git', 'rev-parse', '--show-toplevel']).strip()
+    logger.debug('repo root = %r', self._repo_root)
     return self._repo_root
 
   def _get_sha(self) -> str:
-    sha = _getoutput(['git', 'rev-parse', 'HEAD']).strip()
-    return sha
+    if hasattr(self, '_sha'):
+      return self._sha
+    self._sha = _getoutput(['git', 'rev-parse', 'HEAD']).strip()
+    logger.debug('sha = %r', self._sha)
+    return self._sha
 
   @override
   def get_source_url(self, obj: docspec.ApiObject) -> str:
@@ -74,5 +78,7 @@ class GitHubSourceLinker(Struct):
       return None
     sha = self._get_sha()
     rel_path = os.path.relpath(os.path.abspath(obj.location.filename), repo_root)
-    return 'https://{}/{}/blob/{}/{}#L{}'.format(
+    url = 'https://{}/{}/blob/{}/{}#L{}'.format(
       self.host, self.repo, sha, rel_path, obj.location.lineno)
+    logger.debug('url for api object %r: %r (rel_path: %r)', obj.name, url, rel_path)
+    return url

--- a/pydoc-markdown/src/pydoc_markdown/contrib/source_linkers/github.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/source_linkers/github.py
@@ -79,7 +79,7 @@ class GitHubSourceLinker(Struct):
       return None
     sha = self._get_sha()
     rel_path = os.path.relpath(os.path.abspath(obj.location.filename), repo_root)
-    if nr.fs.issub(rel_path):
+    if not nr.fs.issub(rel_path):
       # The path points outside of the repo_root. Cannot construct the URL in that case.
       logger.debug('rel_path %r points outside of repo_root %r', rel_path, repo_root)
       return None

--- a/pydoc-markdown/src/pydoc_markdown/contrib/source_linkers/github.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/source_linkers/github.py
@@ -26,6 +26,7 @@ from typing import List, Optional, Tuple
 import docspec
 import logging
 import os
+import nr.fs
 import subprocess
 
 logger = logging.getLogger(__name__)
@@ -78,6 +79,10 @@ class GitHubSourceLinker(Struct):
       return None
     sha = self._get_sha()
     rel_path = os.path.relpath(os.path.abspath(obj.location.filename), repo_root)
+    if nr.fs.issub(rel_path):
+      # The path points outside of the repo_root. Cannot construct the URL in that case.
+      logger.debug('rel_path %r points outside of repo_root %r', rel_path, repo_root)
+      return None
     url = 'https://{}/{}/blob/{}/{}#L{}'.format(
       self.host, self.repo, sha, rel_path, obj.location.lineno)
     logger.debug('url for api object %r: %r (rel_path: %r)', obj.name, url, rel_path)

--- a/pydoc-markdown/src/pydoc_markdown/interfaces.py
+++ b/pydoc-markdown/src/pydoc_markdown/interfaces.py
@@ -41,8 +41,24 @@ def _make_union_type(entrypoint_name: str) -> UnionType:
   ))
 
 
+class Context:
+  """
+  Context data that is passed to plugins when they are loaded.
+  """
+
+  def __init__(self, directory: str) -> None:
+    self.directory = directory
+
+
+class PluginBase(Interface):
+
+  @default
+  def init(self, context: Context) -> None:
+    pass
+
+
 @SerializeAs(_make_union_type('pydoc_markdown.interfaces.Loader'))
-class Loader(Interface):
+class Loader(PluginBase):
   """
   This interface describes an object that is capable of loading documentation
   data. The location from which the documentation is loaded must be defined
@@ -69,7 +85,7 @@ class Resolver(Interface):
 
 
 @SerializeAs(_make_union_type('pydoc_markdown.interfaces.Processor'))
-class Processor(Interface):
+class Processor(PluginBase):
   """
   A processor is an object that takes a list of #docspec.Module#s as an input and
   transforms it in an arbitrary way. This usually processes docstrings to convert from
@@ -81,7 +97,7 @@ class Processor(Interface):
 
 
 @SerializeAs(_make_union_type('pydoc_markdown.interfaces.Renderer'))
-class Renderer(Processor):
+class Renderer(PluginBase):
   """
   A renderer is an object that takes a list of #docspec.Module#s as an input and produces
   output files or writes to stdout. It may also expose additional command-line arguments.
@@ -147,7 +163,7 @@ class Builder(Interface):
 
 
 @SerializeAs(_make_union_type('pydoc_markdown.interfaces.SourceLinker'))
-class SourceLinker(Interface):
+class SourceLinker(PluginBase):
   """
   This interface is used to determine the URL to the source of an API object. Renderers
   can use it to place a link to the source in the generated documentation.

--- a/pydoc-markdown/src/pydoc_markdown/main.py
+++ b/pydoc-markdown/src/pydoc_markdown/main.py
@@ -194,8 +194,8 @@ def error(*args):
 @click.version_option(__version__)
 @click.option('--bootstrap', type=click.Choice(['base', 'mkdocs', 'hugo', 'readthedocs']),
   help='Create a Pydoc-Markdown configuration file in the current working directory.')
-@click.option('--verbose', '-v', is_flag=True, help='Increase log verbosity.')
-@click.option('--quiet', '-q', is_flag=True, help='Decrease the log verbosity.')
+@click.option('--verbose', '-v', count=True, help='Increase log verbosity.')
+@click.option('--quiet', '-q', count=True, help='Decrease the log verbosity.')
 @click.option('--module', '-m', 'modules', metavar='MODULE', multiple=True,
   help='The module to parse and generated API documentation for. Can be '
        'specified multiple times. ' + default_config_notice)
@@ -289,14 +289,16 @@ def cli(
   load_implicit_config = not any((modules, packages, search_path, py2 is not None))
 
   # Initialize logging.
-  if verbose is not None:
-    if verbose:
-      level = logging.INFO
-    elif quiet:
-      level = logging.ERROR
-    else:
-      level = logging.WARNING
-    logging.basicConfig(format='[%(levelname)s - %(name)s]: %(message)s', level=level)
+  verbosity = verbose - quiet
+  if verbosity >= 2:
+    level = logging.DEBUG
+  elif verbosity >= 1:
+    level = logging.INFO
+  elif verbosity >= 0:
+    level = logging.ERROR
+  else:
+    level = logging.WARNING
+  logging.basicConfig(format='[%(levelname)s - %(name)s]: %(message)s', level=level)
 
   # Load the configuration.
   if config and (config.lstrip().startswith('{') or '\n' in config):

--- a/pydoc-markdown/src/pydoc_markdown/main.py
+++ b/pydoc-markdown/src/pydoc_markdown/main.py
@@ -33,7 +33,7 @@ from pydoc_markdown import __version__, PydocMarkdown, static
 from pydoc_markdown.contrib.loaders.python import PythonLoader
 from pydoc_markdown.contrib.renderers.markdown import MarkdownRenderer
 from pydoc_markdown.contrib.renderers.mkdocs import MkdocsRenderer
-from pydoc_markdown.interfaces import Server
+from pydoc_markdown.interfaces import Context, Server
 from pydoc_markdown.util.watchdog import watch_paths
 from typing import List, Set, Union
 import click
@@ -117,6 +117,9 @@ class RenderSession:
     if self.config:
       config.load_config(self.config)
     self._apply_overrides(config)
+
+    if isinstance(self.config, str):
+      config.init(Context(directory=os.path.dirname(os.path.abspath(self.config))))
 
     if config.unknown_fields:
       logger.warning('Unknown configuration options: %s', ', '.join(config.unknown_fields))

--- a/pydoc-markdown/src/pydoc_markdown/util/pages.py
+++ b/pydoc-markdown/src/pydoc_markdown/util/pages.py
@@ -153,7 +153,8 @@ class Page(Struct):
       self,
       filename: str,
       modules: List[docspec.ApiObject],
-      renderer: Renderer
+      renderer: Renderer,
+      context_directory: str,
       ) -> None:
     """
     Renders the page by either copying the *source* to the specified *filename* or by
@@ -164,8 +165,8 @@ class Page(Struct):
 
     os.makedirs(os.path.dirname(filename), exist_ok=True)
     if self.source:
-      logger.info('Writing "%s" (source: "%s")', filename, self.source)
-      shutil.copyfile(self.source, filename)
+      logger.info('Writing "%s" (source: "%s")', filename, os.path.join(context_directory, self.source))
+      shutil.copyfile(os.path.join(context_directory, self.source), filename)
     else:
       logger.info('Rendering "%s"', filename)
       renderer.render(self.filtered_modules(modules))


### PR DESCRIPTION
On RTD the source linker constructs the wrong URL because Pydoc-Markdown discovers the Python source files in the `site-packages` directory rather than in the project directory. The relative path that is constructed is totally whack of course. This may be an upstream issue in [docspec_python](https://github.com/NiklasRosenstein/docspec/tree/master/docspec-python).