### PR TITLE
improve view-source appearance

### DIFF
--- a/pydoc-markdown/src/pydoc_markdown/contrib/renderers/markdown.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/renderers/markdown.py
@@ -269,11 +269,11 @@ class MarkdownRenderer(Struct):
   def _render_object(self, fp, level, obj):
     if not isinstance(obj, docspec.Module) or self.render_module_header:
       self._render_header(fp, level, obj)
-    self._render_signature_block(fp, obj)
     if self.source_linker:
       url = self.source_linker.get_source_url(obj)
       if url:
-        fp.write('[[view source]]({})\n\n'.format(url))
+        fp.write('<span style="float: right; font-size: 75%;">\n[[view source]]({})\n</span>\n\n'.format(url))
+    self._render_signature_block(fp, obj)
     if obj.docstring:
       lines = obj.docstring.split('\n')
       if self.docstrings_as_blockquote:


### PR DESCRIPTION
From https://github.com/NiklasRosenstein/pydoc-markdown/pull/135#issuecomment-660022986

Make `[view source]` link

- [x] right-aligned
- [x] smaller font
- [ ] on the same visual line as the heading (https://stackoverflow.com/questions/13194692/align-h1-header-and-normal-text-in-same-line)

Even just the first two help, e.g.:

![image](https://user-images.githubusercontent.com/10780059/87776536-d9182100-c81f-11ea-8f68-3a50a6bfc5cc.png)

using `style="float: right; font-size: 75%;"` changes to:

![image](https://user-images.githubusercontent.com/10780059/87776495-c271ca00-c81f-11ea-8e89-3a409597dfbf.png)
