### PR TITLE
add YTT-like YAML preprocessing when loading configuration

### DIFF
--- a/.changelog/_unreleased.yml
+++ b/.changelog/_unreleased.yml
@@ -29,18 +29,13 @@ changes:
   component: internal
   description: 'Ensure consistency independent of the CWD from which Pydoc-Markdown
     is invoked as long
-
     as the same configuration file is used by introduce the `Context` object and the
     `init()`
-
     method for plugins. The `Context.directory` is set to the parent directory of
     the
-
     `pydoc-markdown.yml` configuration file. Plugins use that directory to interpret
     relative
-
     paths instead of the current working directory.
-
     '
   fixes: []
 - type: feature

--- a/.changelog/_unreleased.yml
+++ b/.changelog/_unreleased.yml
@@ -27,10 +27,24 @@ changes:
   fixes: []
 - type: improvement
   component: internal
-  description: |
-    Ensure consistency independent of the CWD from which Pydoc-Markdown is invoked as long
-    as the same configuration file is used by introduce the `Context` object and the `init()`
-    method for plugins. The `Context.directory` is set to the parent directory of the
-    `pydoc-markdown.yml` configuration file. Plugins use that directory to interpret relative
+  description: 'Ensure consistency independent of the CWD from which Pydoc-Markdown
+    is invoked as long
+
+    as the same configuration file is used by introduce the `Context` object and the
+    `init()`
+
+    method for plugins. The `Context.directory` is set to the parent directory of
+    the
+
+    `pydoc-markdown.yml` configuration file. Plugins use that directory to interpret
+    relative
+
     paths instead of the current working directory.
+
+    '
+  fixes: []
+- type: feature
+  component: general
+  description: implement YTT-like YAML preprocessing when the Pydoc-Markdown configuration
+    is loaded
   fixes: []

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 Pydoc-Markdown will read the configuration from a file called `pydoc-markdown.yml` (or `.yaml`)
 from the current working directory. Usually you would place this file in your project's root
-directory.
+directory. The YAML configuration is pre-processed with a [YTT][]-like templating language.
 
 The file contains of four main sections:
 
@@ -15,6 +15,25 @@ The file contains of four main sections:
 * `renderer`: A plugin that produces the output files. The default configuration defines the
   `markdown` renderer (which by default will render a single file to stdout).
 * `hooks`: Configuration for commands that will be executed before and after rendering.
+
+## YAML Preprocessing
+
+  [YTT]: https://get-ytt.io/
+
+> *New in Pydoc-Markdown 3.3.0. See also `pydoc_markdown.util.ytemplate`*
+
+Pydoc-Markdown performs very basic pre-processing on the YAML configuration before it is
+deserialized. The format is similar to that of [YTT][], but supports only a subset of the
+features and logic is interpreted as actual Python code.
+
+Supportes preprocessing features:
+
+* `def` blocks to define a Python function (requires an `end` keyword, encapsulating YAML
+  code into the function definition is not supported)
+* Value substitution
+
+Check out the [Read the Docs/Hugo baseURL](readthedocs#hugo-baseurl) documentation for an
+example.
 
 ## Loaders
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,7 @@ Supportes preprocessing features:
   code into the function definition is not supported)
 * Value substitution
 
-Check out the [Read the Docs/Hugo baseURL](readthedocs#hugo-baseurl) documentation for an
+Check out the [Read the Docs/Hugo baseURL](../read-the-docs#hugo-baseurl) documentation for an
 example.
 
 ## Loaders

--- a/docs/readthedocs.md
+++ b/docs/readthedocs.md
@@ -33,3 +33,27 @@ steps:
 
 You can use the `pydoc-markdown --bootstrap readthedocs` command as a shortcut to create
 these files.
+
+### Hugo baseURL
+
+When using Hugo, usually you want to set the `baseURL` configuration so that it can generated
+permalinks properly. If you are building on Read the Docs, chances are that you will have
+multiple versions of the documentation, which all require a different `baseURL`.
+
+Pydoc-Markdown configuration files are pre-processed with a [YTT][]-like templating language.
+
+  [YTT]: https://get-ytt.io/
+
+```yml
+#@ def base_url():
+#@    if env.READTHEDOCS:
+#@      return "https://pydoc-markdown.readthedocs.io/en/" + env.READTHEDOCS_VERSION + "/"
+#@    else:
+#@      return None
+#@ end
+
+renderer:
+  type: hugo
+  config:
+    baseURL: #@ base_url()
+```

--- a/pydoc-markdown.yaml
+++ b/pydoc-markdown.yaml
@@ -1,23 +1,38 @@
+
+#@ def base_url():
+#@    if env.READTHEDOCS:
+#@      return "https://pydoc-markdown.readthedocs.io/en/" + env.READTHEDOCS_VERSION + "/"
+#@    else:
+#@      return None
+#@ end
+
 loaders:
   - type: python
     search_path: [pydoc-markdown/src]
+
 hooks:
   pre-render:
   - shut changelog -a --markdown >CHANGELOG.md
+
 renderer:
   type: hugo
-  config:
-    baseURL: "https://pydoc-markdown.readthedocs.io/en/latest/"
-    title: "Pydoc-Markdown"
-    theme: {clone_url: "https://github.com/alex-shpak/hugo-book.git"}
-  build_directory: docs/build
-  content_directory: content/docs  # Book theme will render the pages in content/docs in the nav.
-  default_preamble:
-    menu: main
+
   markdown:
     source_linker:
       type: github
       repo: NiklasRosenstein/pydoc-markdown
+
+  config:
+    baseURL: #@ base_url()
+    title: "Pydoc-Markdown"
+    theme: {clone_url: "https://github.com/alex-shpak/hugo-book.git"}
+
+  build_directory: docs/build
+  content_directory: content/docs  # Book theme will render the pages in content/docs in the nav.
+
+  default_preamble:
+    menu: main
+
   pages:
   - title: Home
     name: index

--- a/pydoc-markdown/src/pydoc_markdown/__init__.py
+++ b/pydoc-markdown/src/pydoc_markdown/__init__.py
@@ -34,9 +34,11 @@ from pydoc_markdown.contrib.processors.filter import FilterProcessor
 from pydoc_markdown.contrib.processors.crossref import CrossrefProcessor
 from pydoc_markdown.contrib.processors.smart import SmartProcessor
 from pydoc_markdown.contrib.renderers.markdown import MarkdownRenderer
+from pydoc_markdown.util import ytemplate
 from typing import List, Union
 import docspec
 import logging
+import os
 import subprocess
 import yaml
 
@@ -91,8 +93,7 @@ class PydocMarkdown(Struct):
     if isinstance(data, str):
       filename = data
       logger.info('Loading configuration file "%s".', filename)
-      with open(data) as fp:
-        data = yaml.safe_load(fp)
+      data = ytemplate.load(filename, {'env': ytemplate.Attributor(os.environ)})
 
     collector = Collect()
     result = mapper.deserialize(data, type(self), filename=filename, decorations=[collector])

--- a/pydoc-markdown/src/pydoc_markdown/util/ytemplate.py
+++ b/pydoc-markdown/src/pydoc_markdown/util/ytemplate.py
@@ -1,0 +1,89 @@
+# -*- coding: utf8 -*-
+# Copyright (c) 2019 Niklas Rosenstein
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+"""
+Template language for YAML files similar to [YTT][].
+
+  [YTT]: https://get-ytt.io/
+"""
+
+from typing import Any, Dict, TextIO, Type, Union
+from nr.collections.chaindict import ChainDict
+import textwrap
+import json
+import yaml
+
+
+def load(
+  file_: Union[str, TextIO],
+  context: Dict[str, Any],
+  Loader: Type[yaml.Loader] = None,
+) -> Any:
+  """
+  Loads a YAML template into a Python object.
+
+  # Arguments
+  file_: The file-like object or filename to load.
+  context: The context variables available to the template.
+  Loader: The #yaml.Loader implementation. Defaults to #yaml.SafeLoader.
+  """
+
+  if isinstance(file_, str):
+    with open(file_) as fp:
+      return load(fp, context, Loader)
+
+  if Loader is None:
+    Loader = yaml.SafeLoader
+
+  yaml_code = []
+  it = iter(file_)
+  for line in it:
+
+    # Parse Python code blocks.
+    if line.startswith('#@'):
+      block_lines = [line[2:]]
+      for line in it:
+        if not line.startswith('#@'):
+          raise ValueError('missing #@ end')
+        if line[2:].strip() == 'end':
+          break
+        block_lines.append(line[2:])
+      code = textwrap.dedent(''.join(block_lines))
+      exec(code, context, context)
+
+    # Inline replacements.
+    index = line.find('#@')
+    if index > 0:
+      line = line[:index] + json.dumps(eval(line[index+2:], context, context)) + '\n'
+
+    yaml_code.append(line)
+
+  return yaml.load(''.join(yaml_code), Loader)
+
+
+class Attributor:
+
+  def __init__(self, data: Dict, default: Any = None) -> None:
+    self._data = data
+    self._default = default
+
+  def __getattr__(self, name: str) -> Any:
+    return self._data.get(name)


### PR DESCRIPTION
The pre-processing can be used to generate the Hugo `baseURL` configuration on demand based on environment variables. This is to address issues with Hugo templates that require the `baseURL` to be correctly configured to function properly (e.g. https://github.com/alex-shpak/hugo-book/issues/246)