### PR TITLE
Quick fixes sidebar

### DIFF
--- a/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
@@ -70,6 +70,9 @@ class DocusaurusRenderer(Struct):
       filepath = output_path
 
       module_parts = module.name.split(".")
+      if module.location.filename.endswith("__init__.py"):
+        module_parts.append("__init__")
+
       relative_module_tree = module_tree
       intermediary_module = []
 

--- a/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
@@ -58,7 +58,7 @@ class DocusaurusRenderer(Struct):
   relative_sidebar_path = Field(str, default='sidebar.json')
 
   #: The top-level label in the sidebar. Default to 'Reference'. Can be set to null to
-  #: remove the sidebar top-level all together.
+  #: remove the sidebar top-level all together. This option assumes that there is only one top-level module.
   sidebar_top_level_label = Field(str, default='Reference', nullable=True)
 
   @override
@@ -112,7 +112,9 @@ class DocusaurusRenderer(Struct):
     }
     self._build_sidebar_tree(sidebar, module_tree)
     if not self.sidebar_top_level_label:
-      sidebar = sidebar['items']
+      # it needs to be a dictionary, not a list; this assumes that
+      # there is only one top-level module
+      sidebar = sidebar['items'][0]
 
     sidebar_path = Path(self.docs_base_path) / self.relative_output_path / self.relative_sidebar_path
     with sidebar_path.open("w") as handle:

--- a/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
@@ -22,7 +22,7 @@ class CustomizedMarkdownRenderer(MarkdownRenderer):
   #: Conforms to Docusaurus header format.
   render_module_header_template = Field(str, default=(
     '---\n'
-    'sidebar_label: {module_name}\n'
+    'sidebar_label: {relative_module_name}\n'
     'title: {module_name}\n'
     '---\n\n'
   ))

--- a/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
@@ -61,6 +61,10 @@ class DocusaurusRenderer(Struct):
   #: remove the sidebar top-level all together. This option assumes that there is only one top-level module.
   sidebar_top_level_label = Field(str, default='Reference', nullable=True)
 
+  #: The top-level module label in the sidebar. Default to null, meaning that the actual
+  #: module name will be used. This option assumes that there is only one top-level module.
+  sidebar_top_level_module_label = Field(str, default=None, nullable=True)
+
   @override
   def render(self, modules: List[docspec.Module]) -> None:
     modules_and_paths = []
@@ -111,10 +115,15 @@ class DocusaurusRenderer(Struct):
       "label": self.sidebar_top_level_label,
     }
     self._build_sidebar_tree(sidebar, module_tree)
-    if not self.sidebar_top_level_label:
-      # it needs to be a dictionary, not a list; this assumes that
-      # there is only one top-level module
-      sidebar = sidebar['items'][0]
+
+    if sidebar.get("items"):
+      if self.sidebar_top_level_module_label:
+        sidebar['items'][0]["label"] = self.sidebar_top_level_module_label
+
+      if not self.sidebar_top_level_label:
+        # it needs to be a dictionary, not a list; this assumes that
+        # there is only one top-level module
+        sidebar = sidebar['items'][0]
 
     sidebar_path = Path(self.docs_base_path) / self.relative_output_path / self.relative_sidebar_path
     with sidebar_path.open("w") as handle:

--- a/pydoc-markdown/src/pydoc_markdown/contrib/renderers/markdown.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/renderers/markdown.py
@@ -206,7 +206,12 @@ class MarkdownRenderer(Struct):
 
   def _render_header(self, fp, level, obj):
     if self.render_module_header_template and isinstance(obj, docspec.Module):
-      fp.write(self.render_module_header_template.format(module_name=obj.name))
+      fp.write(
+        self.render_module_header_template.format(
+          module_name=obj.name,
+          relative_module_name=obj.name.rsplit(".", 1)[1]
+        )
+      )
       return
 
     object_id = self._generate_object_id(obj)

--- a/pydoc-markdown/src/pydoc_markdown/test/test_e2e_docusaurus.py
+++ b/pydoc-markdown/src/pydoc_markdown/test/test_e2e_docusaurus.py
@@ -61,7 +61,7 @@ def test_full_processing():
         stuff_doc = handle.read()
 
     assert_text_equals(stuff_doc, r"""---
-sidebar_label: test_package.module.stuff
+sidebar_label: stuff
 title: test_package.module.stuff
 ---
 

--- a/pydoc-markdown/src/pydoc_markdown/test/test_e2e_docusaurus.py
+++ b/pydoc-markdown/src/pydoc_markdown/test/test_e2e_docusaurus.py
@@ -120,3 +120,43 @@ This is module __init__.py
 This constant is rad
 
 """)
+
+
+def test_full_processing_custom_top_level_names():
+    docs_path = Path(__file__).parent / "test_package" / "docs"
+    config = PydocMarkdown(
+        loaders=[PythonLoader(
+            search_path=[str(Path(__file__).parent.resolve())],
+            packages=['test_package']
+        )],
+        processors=[FilterProcessor(skip_empty_modules=True), CrossrefProcessor(), SmartProcessor()],
+        renderer=DocusaurusRenderer(
+        docs_base_path=str(docs_path.resolve()),
+        sidebar_top_level_label=None,
+        sidebar_top_level_module_label="My test package"
+    ))
+
+    modules = config.load_modules()
+    config.process(modules)
+    config.render(modules)
+
+    sidebar = docs_path / "reference" / "sidebar.json"
+    assert sidebar.exists()
+
+    with sidebar.open("r") as handle:
+        sidebar = json.load(handle)
+
+    assert sidebar == {
+      "items": [
+        {
+          "items": [
+            "reference/test_package/module/__init__",
+            "reference/test_package/module/stuff"
+          ],
+          "label": "test_package.module",
+          "type": "category"
+        }
+      ],
+      "label": "My test package",
+      "type": "category"
+    }

--- a/pydoc-markdown/src/pydoc_markdown/test/test_e2e_docusaurus.py
+++ b/pydoc-markdown/src/pydoc_markdown/test/test_e2e_docusaurus.py
@@ -28,10 +28,14 @@ def test_full_processing():
     config.render(modules)
 
     sidebar = docs_path / "reference" / "sidebar.json"
+    init_md = docs_path / "reference" / "test_package" / "module" / "__init__.md"
+    wrong_module_init_md = docs_path / "reference" / "test_package" / "module.md"
     suff_md = docs_path / "reference" / "test_package" / "module" / "stuff.md"
     assert (docs_path / "reference").is_dir()
     assert sidebar.exists()
     assert suff_md.exists()
+    assert init_md.exists()
+    assert not wrong_module_init_md.exists()
     assert not (docs_path / "reference" / "test_package" / "no_docstrings.md").exists()
 
     with sidebar.open("r") as handle:
@@ -43,6 +47,7 @@ def test_full_processing():
           "items": [
             {
               "items": [
+                "reference/test_package/module/__init__",
                 "reference/test_package/module/stuff"
               ],
               "label": "test_package.module",
@@ -98,4 +103,20 @@ This is a cool attribute.
 ```
 
 Run cool stuff
+""")
+
+    with init_md.open("r") as handle:
+        init_doc = handle.read()
+
+    assert_text_equals(init_doc, r"""---
+sidebar_label: module
+title: test_package.module
+---
+
+This is module __init__.py
+
+#### CONSTANT
+
+This constant is rad
+
 """)

--- a/pydoc-markdown/src/pydoc_markdown/test/test_package/module/__init__.py
+++ b/pydoc-markdown/src/pydoc_markdown/test/test_package/module/__init__.py
@@ -1,0 +1,5 @@
+"""This is module __init__.py"""
+
+
+#: This constant is rad
+CONSTANT = 42


### PR DESCRIPTION
Hi @NiklasRosenstein !

I want to address two issues we met with the renderer I implemented, and I think that other users of the renderer would meet this issues:
- shorten the label of the modules in the docusaurus sidebar, and use relative name instead fo full module name. Seems more natural and will avoid horizontal scrolls
- nest the documentation of a module's `__init__.py` file under the right folder (it wasn't the case, an error on my end)
- fix the rendering of the sidebar in case `sidebar_top_level_label` is null
- add a new option `sidebar_top_level_module_label` that controls the sidebar label of the top-level module (assuming there is only one)

I've implemented these using TDD. Let me know if that works for you 🙏 