### PR TITLE
Remove version limit on watchdog requirement

### DIFF
--- a/pydoc-markdown/setup.py
+++ b/pydoc-markdown/setup.py
@@ -41,7 +41,7 @@ requirements = [
   'PyYAML >=5.3.0,<6.0.0',
   'six >=1.11.0,<2.0.0',
   'toml >=0.10.1,<1.0.0',
-  'watchdog >=0.10.2,<1.0.0',
+  'watchdog >=0.10.2',
 ]
 
 setuptools.setup(


### PR DESCRIPTION
Removed the '<1.0.0' part from the watchdog requirement in setup.py.