### PR TITLE
fix code blocks indentation in SphinxProcessor

### DIFF
--- a/pydoc-markdown/src/pydoc_markdown/contrib/processors/sphinx.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/processors/sphinx.py
@@ -77,14 +77,13 @@ class SphinxProcessor(Struct):
     components: Dict[str, List[str]] = {}
 
     for line in node.docstring.split('\n'):
-      line = line.strip()
-
-      if line.startswith("```"):
+      if line.strip().startswith("```"):
         in_codeblock = not in_codeblock
 
       line_codeblock = line.startswith('    ')
 
       if not in_codeblock and not line_codeblock:
+        line = line.strip()
         match = re.match(r'\s*:(?:arg|argument|param|parameter)\s+(\w+)\s*:(.*)?$', line)
         if match:
           keyword = 'Arguments'

--- a/pydoc-markdown/src/test/test_processors/test_sphinx.py
+++ b/pydoc-markdown/src/test/test_processors/test_sphinx.py
@@ -20,3 +20,32 @@ def test_sphinx_processor(processor=None):
 
   Something funny.
   ''')
+
+  # check code blocks indentation
+  assert_processor_result(processor or SphinxProcessor(),
+  '''
+  Code example:
+  ```
+  with a() as b:
+    b()
+  ```
+  Implicit block:
+      c()
+  A longer one:
+      d()
+      with e() as f:
+        f()
+  ''',
+  '''
+  Code example:
+  ```
+  with a() as b:
+    b()
+  ```
+  Implicit block:
+      c()
+  A longer one:
+      d()
+      with e() as f:
+        f()
+  ''')


### PR DESCRIPTION
Previously, indentation was removed for all lines in docstring,
including the code blocks. For example,
```
    ```
    with awesome(foo) as aww:
        aww.dostuff()
    ```
```
would be converted to:
```
    ```
    with awesome(foo) as aww:
    aww.dostuff()
    ```
```
This commit fixes this, preserving the indentation inside code blocks.

Closes https://github.com/NiklasRosenstein/pydoc-markdown/issues/179.