### PR TITLE
Docusaurus: sort sidebar items

### DIFF
--- a/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/renderers/docusaurus.py
@@ -5,7 +5,7 @@ from nr.interface import implements, override
 from pathlib import Path
 from pydoc_markdown.interfaces import Renderer
 from pydoc_markdown.contrib.renderers.markdown import MarkdownRenderer
-from typing import Any, Dict, List, Text
+from typing import Any, Dict, List, Text, Tuple, Union
 import docspec
 import json
 import logging
@@ -148,3 +148,14 @@ class DocusaurusRenderer(Struct):
       }
       self._build_sidebar_tree(child, child_tree)
       sidebar["items"].append(child)
+
+    def _sort_items(item: Union[Text, Dict[Text, Any]]) -> Tuple[int, Text]:
+      """Sort sidebar items. Order follows:
+        1. modules containing items come first
+        2. alphanumeric order is applied
+      """
+      is_edge = int(isinstance(item, str))
+      label = item if is_edge else item.get("label")
+      return is_edge, label
+
+    sidebar["items"] = sorted(sidebar["items"], key=_sort_items)

--- a/pydoc-markdown/src/test/a_test_package/docs/reference/sidebar.json
+++ b/pydoc-markdown/src/test/a_test_package/docs/reference/sidebar.json
@@ -3,6 +3,7 @@
     {
       "items": [
         "reference/a_test_package/module/__init__",
+        "reference/a_test_package/module/other_stuff",
         "reference/a_test_package/module/stuff"
       ],
       "label": "a_test_package.module",

--- a/pydoc-markdown/src/test/a_test_package/module/other_stuff.py
+++ b/pydoc-markdown/src/test/a_test_package/module/other_stuff.py
@@ -1,0 +1,29 @@
+"""
+This is a module about stuff.
+"""
+
+
+#: this is a constant about stuff
+CONSTANT = "stuff"
+
+
+def my_funct():
+    """
+    Do something, or nothing.
+    """
+    pass
+
+
+class CoolStuff:
+    """
+    Super cool stuff.
+    """
+
+    #: This is a cool attribute.
+    cool_attr = "cool"
+
+    def run_cool_stuff(self):
+        """
+        Run cool stuff
+        """
+        pass

--- a/pydoc-markdown/src/test/test_e2e_docusaurus.py
+++ b/pydoc-markdown/src/test/test_e2e_docusaurus.py
@@ -31,6 +31,7 @@ def test_full_processing():
     init_md = docs_path / "reference" / "a_test_package" / "module" / "__init__.md"
     wrong_module_init_md = docs_path / "reference" / "a_test_package" / "module.md"
     suff_md = docs_path / "reference" / "a_test_package" / "module" / "stuff.md"
+    other_suff_md = docs_path / "reference" / "a_test_package" / "module" / "other_stuff.md"
     assert (docs_path / "reference").is_dir()
     assert sidebar.exists()
     assert suff_md.exists()
@@ -48,6 +49,7 @@ def test_full_processing():
             {
               "items": [
                 "reference/a_test_package/module/__init__",
+                "reference/a_test_package/module/other_stuff",
                 "reference/a_test_package/module/stuff"
               ],
               "label": "a_test_package.module",
@@ -151,6 +153,7 @@ def test_full_processing_custom_top_level_names():
         {
           "items": [
             "reference/a_test_package/module/__init__",
+            "reference/a_test_package/module/other_stuff",
             "reference/a_test_package/module/stuff"
           ],
           "label": "a_test_package.module",


### PR DESCRIPTION
## Proposal
Sort sidebar items. Today the order is somewhat arbitrary. Here's the proposed sorting strategy:
1. put sidebar items with children at the top, then "edges" below
2. sort each of these categories using alphanumeric order

This PR contains:
- [x] tests