### PR TITLE
Option to remove '|' before function signature.

### DIFF
--- a/pydoc-markdown/src/pydoc_markdown/contrib/renderers/markdown.py
+++ b/pydoc-markdown/src/pydoc_markdown/contrib/renderers/markdown.py
@@ -117,6 +117,9 @@ class MarkdownRenderer(Struct):
   #: Render the function signature in the header. This is disabled by default.
   signature_in_header = Field(bool, default=False)
 
+  #: Render the vertical bar '|' before function signature. This is enabled by default.
+  signature_with_vertical_bar = Field(bool, default=True)
+
   #: Include the "def" keyword in the function signature. This is enabled
   #: by default.
   signature_with_def = Field(bool, default=False)
@@ -266,8 +269,14 @@ class MarkdownRenderer(Struct):
     if self.signature_python_help_style:
       code = cls.path() + ' = ' + code
     if self.classdef_render_init_signature_if_needed and '__init__' in cls.members:
-      code += ':\n |  ' + self._format_function_signature(
-        cls.members['__init__'], override_name=cls.name, add_method_bar=False)
+      code += ':\n '
+      if self.signature_with_vertical_bar:
+        code += "|  "
+      else:
+        code += "   "
+      
+      code += self._format_function_signature(cls.members['__init__'], override_name=cls.name, add_method_bar=False)
+
     if cls.decorations and self.classdef_with_decorators:
       code = '\n'.join(self._format_decorations(cls.decorations)) + code
     return code
@@ -282,7 +291,7 @@ class MarkdownRenderer(Struct):
     if self.classdef_code_block and isinstance(obj, docspec.Class):
       code = self._format_classdef_signature(obj)
     elif self.signature_code_block and isinstance(obj, docspec.Function):
-      code = self._format_function_signature(obj)
+      code = self._format_function_signature(obj, add_method_bar=self.signature_with_vertical_bar)
     elif self.data_code_block and isinstance(obj, docspec.Data):
       code = self._format_data_signature(obj)
     else:

--- a/pydoc-markdown/src/test/test_e2e_markdown.py
+++ b/pydoc-markdown/src/test/test_e2e_markdown.py
@@ -176,6 +176,45 @@ def test_class():
   - `param`: A parameter.
   ''')
 
+  assert_code_as_markdown(
+  '''
+  class Class:
+    """
+    The class documentation!
+    """
+
+    def __init__(self, param):
+      """
+      The constructor.
+
+      :param param: A parameter.
+      """
+      self.param = param
+  ''',
+  '''
+  ## Class Objects
+
+  ```python
+  class Class()
+  ```
+
+  The class documentation!
+
+  #### \\_\\_init\\_\\_
+
+  ```python
+  __init__(param)
+  ```
+
+  The constructor.
+
+  **Arguments**:
+
+  - `param`: A parameter.
+  ''',
+  renderer_options={'signature_with_vertical_bar': False})
+  
+
 
 def test_enum():
   assert_code_as_markdown(


### PR DESCRIPTION
https://github.com/NiklasRosenstein/pydoc-markdown/issues/190