### PR TITLE
Update markdown defaults

### DIFF
--- a/.changelog/_unreleased.yml
+++ b/.changelog/_unreleased.yml
@@ -1,0 +1,6 @@
+changes:
+- type: fix
+  component: general
+  description: fix use of `docspec.ApiObject.path` after we migrated away from using
+    deprecated `docspec.ReverseMap`
+  fixes: []

--- a/.changelog/_unreleased.yml
+++ b/.changelog/_unreleased.yml
@@ -4,3 +4,9 @@ changes:
   description: fix use of `docspec.ApiObject.path` after we migrated away from using
     deprecated `docspec.ReverseMap`
   fixes: []
+- type: change
+  component: general
+  description: change default configuration of `MarkdownRenderer` (`signature_with_vertical_bar
+    = False` (many people seemed to dislike that) and `signature_with_def = True`
+    (for consistency with the included `class` keyword for classes))
+  fixes: []

--- a/src/pydoc_markdown/contrib/renderers/markdown.py
+++ b/src/pydoc_markdown/contrib/renderers/markdown.py
@@ -32,6 +32,10 @@ from pydoc_markdown.interfaces import Context, Renderer, Resolver, SourceLinker
 from pydoc_markdown.util.docspec import format_function_signature, is_method
 
 
+def dotted_name(obj: docspec.ApiObject) -> str:
+  return '.'.join(x.name for x in obj.path)
+
+
 @dataclasses.dataclass
 class MarkdownRenderer(Renderer):
   """
@@ -254,7 +258,7 @@ class MarkdownRenderer(Renderer):
     if self.signature_with_decorators:
       parts += self._format_decorations(func.decorations)
     if self.signature_python_help_style and not self._is_method(func):
-      parts.append('{} = '.format(func.path()))
+      parts.append('{} = '.format(dotted_name(func)))
     parts += [x + ' ' for x in func.modifiers or []]
     if self.signature_with_def:
       parts.append('def ')
@@ -275,7 +279,7 @@ class MarkdownRenderer(Renderer):
       bases += ', metaclass=' + str(cls.metaclass)
     code = 'class {}({})'.format(cls.name, bases)
     if self.signature_python_help_style:
-      code = cls.path() + ' = ' + code
+      code = dotted_name(cls) + ' = ' + code
     if self.classdef_render_init_signature_if_needed and '__init__' in cls.members:
       code += ':\n '
       if self.signature_with_vertical_bar:
@@ -338,7 +342,7 @@ class MarkdownRenderer(Renderer):
        (self.add_member_class_prefix and isinstance(obj, docspec.Data)):
       title = self._get_parent(obj).name + '.' + title
     elif self.add_full_prefix and not self._is_method(obj):
-      title = obj.path()
+      title = dotted_name(obj)
     if (not self.add_module_prefix and isinstance(obj, docspec.Module)):
       title = title.split('.')[-1]
     if isinstance(obj, docspec.Function):

--- a/src/pydoc_markdown/contrib/renderers/markdown.py
+++ b/src/pydoc_markdown/contrib/renderers/markdown.py
@@ -129,11 +129,11 @@ class MarkdownRenderer(Renderer):
   signature_in_header: bool = False
 
   #: Render the vertical bar '|' before function signature. This is enabled by default.
-  signature_with_vertical_bar: bool = True
+  signature_with_vertical_bar: bool = False
 
   #: Include the "def" keyword in the function signature. This is enabled
   #: by default.
-  signature_with_def: bool = False
+  signature_with_def: bool = True
 
   #: Render the class name in the code block for function signature. Note
   #: that this results in invalid Python syntax to be rendered. This is

--- a/src/test/renderers/test_docusaurus.py
+++ b/src/test/renderers/test_docusaurus.py
@@ -84,7 +84,7 @@ this is a constant about stuff
 #### my\_funct
 
 ```python
-my_funct()
+def my_funct()
 ```
 
 Do something, or nothing.
@@ -104,7 +104,7 @@ This is a cool attribute.
 #### run\_cool\_stuff
 
 ```python
- | run_cool_stuff()
+def run_cool_stuff()
 ```
 
 Run cool stuff

--- a/src/test/renderers/test_markdown.py
+++ b/src/test/renderers/test_markdown.py
@@ -12,7 +12,7 @@ from pydoc_markdown import PydocMarkdown
 from pydoc_markdown.contrib.renderers.markdown import MarkdownRenderer
 from pydoc_markdown.contrib.processors.filter import FilterProcessor
 from pydoc_markdown.contrib.processors.smart import SmartProcessor
-from ..utils import Case, assert_text_equals, load_testcase, testcases_for
+from ..utils import Case, assert_text_equals, load_testcase, get_testcases_for
 
 
 @dataclasses.dataclass
@@ -58,7 +58,7 @@ def assert_code_as_markdown(source_code, markdown, full=False, parser_options=No
   assert_text_equals(result, textwrap.dedent(markdown))
 
 
-@pytest.mark.parametrize('filename', testcases_for('renderers/markdown'))
+@pytest.mark.parametrize('filename', get_testcases_for('renderers/markdown'))
 def test_markdown_renderer(filename: str) -> None:
   case = load_testcase('renderers/markdown', filename)
   config = databind.json.load(case.config, MarkdownTestConfig)

--- a/src/test/renderers/test_markdown.py
+++ b/src/test/renderers/test_markdown.py
@@ -12,7 +12,7 @@ from pydoc_markdown import PydocMarkdown
 from pydoc_markdown.contrib.renderers.markdown import MarkdownRenderer
 from pydoc_markdown.contrib.processors.filter import FilterProcessor
 from pydoc_markdown.contrib.processors.smart import SmartProcessor
-from ..utils import Case, assert_text_equals, load_testcases
+from ..utils import Case, assert_text_equals, load_testcase, testcases_for
 
 
 @dataclasses.dataclass
@@ -58,8 +58,9 @@ def assert_code_as_markdown(source_code, markdown, full=False, parser_options=No
   assert_text_equals(result, textwrap.dedent(markdown))
 
 
-@pytest.mark.parametrize('case', load_testcases('renderers/markdown'))
-def test_markdown_renderer(case: Case) -> None:
+@pytest.mark.parametrize('filename', testcases_for('renderers/markdown'))
+def test_markdown_renderer(filename: str) -> None:
+  case = load_testcase('renderers/markdown', filename)
   config = databind.json.load(case.config, MarkdownTestConfig)
   modules = [load_string_as_module(case.filename, case.code, options=config.parser)]
   config.filter.process(modules, None)

--- a/src/test/testcases/renderers/markdown/class_02_with_property.txt
+++ b/src/test/testcases/renderers/markdown/class_02_with_property.txt
@@ -39,7 +39,7 @@ class MyClass()
 #### get\_my\_read\_only\_var
 
 ```python
- | get_my_read_only_var() -> int
+def get_my_read_only_var() -> int
 ```
 
 returns the my_read_only_var variable but is accessed like a method
@@ -50,8 +50,8 @@ Ex:
 #### my\_read\_only\_var
 
 ```python
- | @property
- | my_read_only_var() -> int
+@property
+def my_read_only_var() -> int
 ```
 
 also returns my_read_only_var but is accessed like a normal property

--- a/src/test/testcases/renderers/markdown/class_03_docstring_types.txt
+++ b/src/test/testcases/renderers/markdown/class_03_docstring_types.txt
@@ -70,7 +70,7 @@ The class documentation!
 #### \_\_init\_\_
 
 ```python
- | __init__(param)
+def __init__(param)
 ```
 
 The constructor.

--- a/src/test/testcases/renderers/markdown/func_01.txt
+++ b/src/test/testcases/renderers/markdown/func_01.txt
@@ -16,7 +16,7 @@ def func(s: str) -> List[str]:
 #### func
 
 ```python
-func(s: str) -> List[str]
+def func(s: str) -> List[str]
 ```
 
 Docstring goes here.

--- a/src/test/testcases/renderers/markdown/func_02_starred_args.txt
+++ b/src/test/testcases/renderers/markdown/func_02_starred_args.txt
@@ -16,7 +16,7 @@ def c(abc, *, defg):
 #### a
 
 ```python
-a(*args, **kwargs)
+def a(*args, **kwargs)
 ```
 
 Docstring goes here.
@@ -26,7 +26,7 @@ Docstring goes here.
 #### b
 
 ```python
-b(abc)
+def b(abc)
 ```
 
 Docstring goes here.
@@ -36,7 +36,7 @@ Docstring goes here.
 #### c
 
 ```python
-c(abc, *, defg)
+def c(abc, *, defg)
 ```
 
 Docstring goes here.

--- a/src/test/testcases/renderers/markdown/toc_01_no_module_prefix.txt
+++ b/src/test/testcases/renderers/markdown/toc_01_no_module_prefix.txt
@@ -30,7 +30,7 @@ My module docstring.
 #### foo
 
 ```python
-foo()
+def foo()
 ```
 
 Do bar

--- a/src/test/utils.py
+++ b/src/test/utils.py
@@ -20,7 +20,7 @@ def assert_text_equals(a: str, b: str) -> None:
          '\n'.join([x.rstrip() for x in b.strip().split('\n')])
 
 
-def testcases_for(folder_name: str) -> t.List[str]:
+def get_testcases_for(folder_name: str) -> t.List[str]:
   return [f.name for f in (Path(__file__).parent / 'testcases' / folder_name).iterdir() if f.suffix == '.txt']
 
 

--- a/src/test/utils.py
+++ b/src/test/utils.py
@@ -20,13 +20,13 @@ def assert_text_equals(a: str, b: str) -> None:
          '\n'.join([x.rstrip() for x in b.strip().split('\n')])
 
 
-def load_testcases(folder_name: str) -> t.List[Case]:
-  files = [f for f in (Path(__file__).parent / 'testcases' / folder_name).iterdir() if f.suffix == '.txt']
-  result: t.List[Case] = []
-  for path in files:
-    parts = re.split(r'-{4,}\n', path.read_text())
-    assert parts[0] == ''
-    config, code, output = parts[1:]
-    config = yaml.safe_load(config) if config.strip() else {}
-    result.append(Case(path, config, code, output))
-  return result
+def testcases_for(folder_name: str) -> t.List[str]:
+  return [f.name for f in (Path(__file__).parent / 'testcases' / folder_name).iterdir() if f.suffix == '.txt']
+
+
+def load_testcase(folder_name: str, testcase_name: str) -> Case:
+  path = Path(__file__).parent / 'testcases' / folder_name / testcase_name
+  parts = re.split(r'-{4,}\n', path.read_text())
+  assert parts[0] == ''
+  config, code, output = parts[1:]
+  return Case(path, yaml.safe_load(config) if config.strip() else {}, code, output)


### PR DESCRIPTION
Also fix usage of `docspec.ApiObject.path` in `MarkdownRenderer`