### PR TITLE
Update and refactor sphinx processor tests

### DIFF
--- a/.changelog/_unreleased.yml
+++ b/.changelog/_unreleased.yml
@@ -1,0 +1,5 @@
+changes:
+  - type: refactor
+    component: tests
+    description: Refactor sphinx processor tests and add new test for param keyword only. Fixes minor issue with argument only docstring. @gmarks2149
+    fixes: []

--- a/src/pydoc_markdown/contrib/processors/sphinx.py
+++ b/src/pydoc_markdown/contrib/processors/sphinx.py
@@ -93,6 +93,7 @@ class SphinxProcessor(Processor):
     return_: t.Optional[_ParamLine] = None
 
     for line in node.docstring.split('\n'):
+      keyword = None
       if line.strip().startswith("```"):
         in_codeblock = not in_codeblock
 

--- a/src/pydoc_markdown/contrib/processors/sphinx.py
+++ b/src/pydoc_markdown/contrib/processors/sphinx.py
@@ -76,7 +76,7 @@ class SphinxProcessor(Processor):
 
   def check_docstring_format(self, docstring: str) -> bool:
     return ':param' in docstring or ':return' in docstring or \
-      ':raise' in docstring
+      ':raise' in docstring or ':arg' in docstring
 
   def process(self, modules: t.List[docspec.Module], resolver: t.Optional[Resolver]) -> None:
     docspec.visit(modules, self._process)

--- a/src/test/processors/test_smart.py
+++ b/src/test/processors/test_smart.py
@@ -2,18 +2,11 @@
 from . import test_google, test_pydocmd, test_sphinx
 from pydoc_markdown.contrib.processors.smart import SmartProcessor
 
+# Testing the SmartProcessor with sphinx docstrings has moved to the test_sphinx.py module
+
 
 def test_google_style():
   test_google.test_google_processor(SmartProcessor())
-
-
-def test_sphinx_style():
-  # Dynamically call all tests within the test_sphinx module
-  test_sphinx_attr_names = dir(test_sphinx)
-  for attr_name in test_sphinx_attr_names:
-    sphinx_attr = getattr(test_sphinx, attr_name)
-    if callable(sphinx_attr) and attr_name.startswith("test"):
-      sphinx_attr(SmartProcessor())
 
 
 def test_pydocmd_style():

--- a/src/test/processors/test_smart.py
+++ b/src/test/processors/test_smart.py
@@ -8,7 +8,12 @@ def test_google_style():
 
 
 def test_sphinx_style():
-  test_sphinx.test_sphinx_processor(SmartProcessor())
+  # Dynamically call all tests within the test_sphinx module
+  test_sphinx_attr_names = dir(test_sphinx)
+  for attr_name in test_sphinx_attr_names:
+    sphinx_attr = getattr(test_sphinx, attr_name)
+    if callable(sphinx_attr) and attr_name.startswith("test"):
+      sphinx_attr(SmartProcessor())
 
 
 def test_pydocmd_style():

--- a/src/test/processors/test_sphinx.py
+++ b/src/test/processors/test_sphinx.py
@@ -3,13 +3,14 @@ from . import assert_processor_result
 from pydoc_markdown.contrib.processors.sphinx import SphinxProcessor
 
 
-def test_sphinx_processor(processor=None):
-  assert_processor_result(processor or SphinxProcessor(),
+docstring_with_param_return = \
   '''
   :param s: A string.
   :param b: An int.
   :return: Something funny.
-  ''',
+  '''
+
+md_with_param_return = \
   '''
   **Arguments**:
 
@@ -19,10 +20,9 @@ def test_sphinx_processor(processor=None):
   **Returns**:
 
   Something funny.
-  ''')
+  '''
 
-  # check code blocks indentation
-  assert_processor_result(processor or SphinxProcessor(),
+docstring_with_codeblocks = \
   '''
   Code example:
   ```
@@ -35,7 +35,9 @@ def test_sphinx_processor(processor=None):
       d()
       with e() as f:
         f()
-  ''',
+  '''
+
+md_with_codeblocks = \
   '''
   Code example:
   ```
@@ -48,9 +50,9 @@ def test_sphinx_processor(processor=None):
       d()
       with e() as f:
         f()
-  ''')
+  '''
 
-  assert_processor_result(processor or SphinxProcessor(),
+docstring_with_param_type_returns_rtype = \
   '''
   :param foo: A foo value
   :type foo: str
@@ -58,7 +60,9 @@ def test_sphinx_processor(processor=None):
   :param bar: A bar value
   :returns: Some eggs from foo and bar
   :rtype: str
-  ''',
+  '''
+
+md_with_param_type_returns_rtype = \
   '''
   **Arguments**:
 
@@ -68,4 +72,38 @@ def test_sphinx_processor(processor=None):
   **Returns**:
 
   `str`: Some eggs from foo and bar
-  ''')
+  '''
+
+docstring_with_param = \
+  '''
+  :param foo: The value of foo
+  :param bar: The value of bar
+  '''
+
+md_with_param = \
+  '''
+  **Arguments**:
+
+  - `foo`: The value of foo
+  - `bar`: The value of bar
+  '''
+
+def test_sphinx_with_param_return(processor=SphinxProcessor()):
+  """Test sphinx processor with param and return keywords."""
+  assert_processor_result(processor, docstring_with_param_return, md_with_param_return)
+
+
+def test_sphinx_with_codeblocks(processor=SphinxProcessor()):
+  """Test sphinx processor with codeblocks"""
+  assert_processor_result(processor, docstring_with_codeblocks, md_with_codeblocks)
+
+
+def test_sphinx_with_param_type_returns_rtype(processor=SphinxProcessor()):
+  """Test sphinx processor with param, type, returns, rtype keywords"""
+  assert_processor_result(processor, docstring_with_param_type_returns_rtype, md_with_param_type_returns_rtype)
+
+
+def test_sphinx_with_param(processor=SphinxProcessor()):
+  """Test sphinx processor with only param keyword."""
+  assert_processor_result(processor, docstring_with_param, md_with_param)
+

--- a/src/test/processors/test_sphinx.py
+++ b/src/test/processors/test_sphinx.py
@@ -1,26 +1,9 @@
+import pytest
 
 from . import assert_processor_result
 from pydoc_markdown.contrib.processors.sphinx import SphinxProcessor
+from pydoc_markdown.contrib.processors.smart import SmartProcessor
 
-
-docstring_with_param_return = \
-  '''
-  :param s: A string.
-  :param b: An int.
-  :return: Something funny.
-  '''
-
-md_with_param_return = \
-  '''
-  **Arguments**:
-
-  - `s`: A string.
-  - `b`: An int.
-
-  **Returns**:
-
-  Something funny.
-  '''
 
 docstring_with_codeblocks = \
   '''
@@ -74,12 +57,6 @@ md_with_param_type_returns_rtype = \
   `str`: Some eggs from foo and bar
   '''
 
-docstring_with_param = \
-  '''
-  :param foo: The value of foo
-  :param bar: The value of bar
-  '''
-
 md_with_param = \
   '''
   **Arguments**:
@@ -88,30 +65,112 @@ md_with_param = \
   - `bar`: The value of bar
   '''
 
+doc_with_param_tmp = \
+  '''
+  :{pkey} foo: The value of foo
+  :{pkey} bar: The value of bar
+  '''
 
-def test_sphinx_with_param_return(processor=None):
-  """Test sphinx processor with param and return keywords."""
-  if processor is None:
-    processor = SphinxProcessor()
-  assert_processor_result(processor, docstring_with_param_return, md_with_param_return)
+doc_with_param_type_adjacent_tmp = \
+  '''
+  :{pkey} foo: The value of foo
+  :type foo: str
+  :{pkey} bar: The value of bar
+  :type bar: int
+  '''
+
+doc_with_param_type_mixed_tmp = \
+  '''
+  :{pkey} foo: The value of foo
+  :type bar: int
+  :type foo: str
+  :{pkey} bar: The value of bar
+  '''
+
+md_with_param_type = \
+  '''
+  **Arguments**:
+  
+  - `foo` (`str`): The value of foo
+  - `bar` (`int`): The value of bar
+  '''
+
+doc_with_param_return_tmp = \
+  '''
+  :param foo: Another value of foo
+  :{rkey}: A description of return value
+  '''
+
+md_with_param_return = \
+  '''
+  **Arguments**:
+  
+  - `foo`: Another value of foo
+  
+  **Returns**:
+  
+  A description of return value
+  '''
+
+doc_with_raise_tmp = \
+  '''
+  :{rkey} KeyError: A key is missing
+  '''
+
+md_with_raise = \
+  '''
+  **Raises**:
+  
+  - `KeyError`: A key is missing
+  '''
+
+@pytest.mark.parametrize("processor", [SphinxProcessor(), SmartProcessor()])
+@pytest.mark.parametrize("keyword", ["arg", "argument", "param", "parameter"])
+def test_sphinx_with_param(processor, keyword):
+  """Test sphinx docstrings with valid param keywords"""
+  docstring = doc_with_param_tmp.format(pkey=keyword)
+  assert_processor_result(processor, docstring, md_with_param)
 
 
-def test_sphinx_with_codeblocks(processor=None):
-  """Test sphinx processor with codeblocks"""
-  if processor is None:
-    processor = SphinxProcessor()
+@pytest.mark.parametrize("processor", [SphinxProcessor(), SmartProcessor()])
+@pytest.mark.parametrize("keyword", ["arg", "argument", "param", "parameter"])
+def test_sphinx_with_param_type_adjacent(processor, keyword):
+  """Test sphinx docstrings with valid param keywords with types"""
+  docstring = doc_with_param_type_adjacent_tmp.format(pkey=keyword)
+  assert_processor_result(processor, docstring, md_with_param_type)
+
+
+@pytest.mark.parametrize("processor", [SphinxProcessor(), SmartProcessor()])
+@pytest.mark.parametrize("keyword", ["arg", "argument", "param", "parameter"])
+def test_sphinx_with_param_type_mixed(processor, keyword):
+  """Test sphinx docstrings with valid param keywords with types out of order"""
+  docstring = doc_with_param_type_mixed_tmp.format(pkey=keyword)
+  assert_processor_result(processor, docstring, md_with_param_type)
+
+
+@pytest.mark.parametrize("processor", [SphinxProcessor(), SmartProcessor()])
+@pytest.mark.parametrize("keyword", ["return", "returns"])
+def test_sphinx_with_param_return(processor, keyword):
+  """Test sphinx docstrings with valid return keywords"""
+  docstring = doc_with_param_return_tmp.format(rkey=keyword)
+  assert_processor_result(processor, docstring, md_with_param_return)
+
+
+@pytest.mark.parametrize("processor", [SphinxProcessor(), SmartProcessor()])
+@pytest.mark.parametrize("keyword", ["raise", "raises"])
+def test_sphinx_with_raise(processor, keyword):
+  """Test sphinx docstrings with valid raise keywords"""
+  docstring = doc_with_raise_tmp.format(rkey=keyword)
+  assert_processor_result(processor, docstring, md_with_raise)
+
+
+@pytest.mark.parametrize("processor", [SphinxProcessor(), SmartProcessor()])
+def test_sphinx_with_codeblocks(processor):
+  """Test sphinx docstrings with codeblocks"""
   assert_processor_result(processor, docstring_with_codeblocks, md_with_codeblocks)
 
 
-def test_sphinx_with_param_type_returns_rtype(processor=None):
+@pytest.mark.parametrize("processor", [SphinxProcessor(), SmartProcessor()])
+def test_sphinx_with_param_type_returns_rtype(processor):
   """Test sphinx processor with param, type, returns, rtype keywords"""
-  if processor is None:
-    processor = SphinxProcessor()
   assert_processor_result(processor, docstring_with_param_type_returns_rtype, md_with_param_type_returns_rtype)
-
-
-def test_sphinx_with_param(processor=None):
-  """Test sphinx processor with only param keyword."""
-  if processor is None:
-    processor = SphinxProcessor()
-  assert_processor_result(processor, docstring_with_param, md_with_param)

--- a/src/test/processors/test_sphinx.py
+++ b/src/test/processors/test_sphinx.py
@@ -88,22 +88,30 @@ md_with_param = \
   - `bar`: The value of bar
   '''
 
-def test_sphinx_with_param_return(processor=SphinxProcessor()):
+
+def test_sphinx_with_param_return(processor=None):
   """Test sphinx processor with param and return keywords."""
+  if processor is None:
+    processor = SphinxProcessor()
   assert_processor_result(processor, docstring_with_param_return, md_with_param_return)
 
 
-def test_sphinx_with_codeblocks(processor=SphinxProcessor()):
+def test_sphinx_with_codeblocks(processor=None):
   """Test sphinx processor with codeblocks"""
+  if processor is None:
+    processor = SphinxProcessor()
   assert_processor_result(processor, docstring_with_codeblocks, md_with_codeblocks)
 
 
-def test_sphinx_with_param_type_returns_rtype(processor=SphinxProcessor()):
+def test_sphinx_with_param_type_returns_rtype(processor=None):
   """Test sphinx processor with param, type, returns, rtype keywords"""
+  if processor is None:
+    processor = SphinxProcessor()
   assert_processor_result(processor, docstring_with_param_type_returns_rtype, md_with_param_type_returns_rtype)
 
 
-def test_sphinx_with_param(processor=SphinxProcessor()):
+def test_sphinx_with_param(processor=None):
   """Test sphinx processor with only param keyword."""
+  if processor is None:
+    processor = SphinxProcessor()
   assert_processor_result(processor, docstring_with_param, md_with_param)
-


### PR DESCRIPTION
I'm actually interested in working towards a resolution for issue #195. Before I got too far with that I wanted to make sure any changes didn't introduce any regressions so I started looking at the sphinx processor tests. They didn't seem to cover all the possible scenarios so I started looking at adding some tests. In that process I discovered the minor issue fixed here where an extra line was introduced between the Arguments heading and the table of arguments if the the only keywords used in the docstring (or more precisely, if the last keyword used in the docstring) was a param/argument keyword.

If the last keyword processed was an argument keyword, and there was a newline after it, the processor processes the last empty line but the keyword variable is still set to 'Arguments' so it gets added to the Arguments component list instead of the lines list.

My intent is to follow this up with some additional sphinx processor tests. Primary to verify that sample docstrings contain any of the expected variations of the keywords (Ex. arg/argument/parameter which currently aren't tested). After that I hope to submit a potential fix for issue #195.