### PR TITLE
Proposal for fixing sphinx multi-line parsing error

### DIFF
--- a/.changelog/_unreleased.yml
+++ b/.changelog/_unreleased.yml
@@ -9,3 +9,8 @@ changes:
   component: tests
   description: Refactor sphinx processor tests and add new test for param keyword only. Fixes minor issue with argument only docstring. @gmarks2149
   fixes: []
+- type: fix
+  component: sphinx_processor
+  description: Fix multi-line parameter sphinx docstring rendering issue by switching to docstring-parser to parse the docstrings. @gmarks2149
+  fixes:
+  - '#195'

--- a/package.yml
+++ b/package.yml
@@ -15,6 +15,7 @@ requirements:
 - databind.json ^1.2.2
 - docspec ^1.0.0
 - docspec-python ^1.0.0
+- docstring-parser ^0.11
 - nr.fs ^1.6.0
 - nr.stream ^0.1.2
 - requests ^2.23.0

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ requirements = [
   'databind.json >=1.2.2,<2.0.0',
   'docspec >=1.0.0,<2.0.0',
   'docspec-python >=1.0.0,<2.0.0',
+  'docstring-parser',
   'nr.fs >=1.6.0,<2.0.0',
   'nr.stream >=0.1.2,<1.0.0',
   'requests >=2.23.0,<3.0.0',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ requirements = [
   'databind.json >=1.2.2,<2.0.0',
   'docspec >=1.0.0,<2.0.0',
   'docspec-python >=1.0.0,<2.0.0',
-  'docstring-parser',
+  'docstring-parser >=0.11',
   'nr.fs >=1.6.0,<2.0.0',
   'nr.stream >=0.1.2,<1.0.0',
   'requests >=2.23.0,<3.0.0',

--- a/src/test/processors/test_sphinx.py
+++ b/src/test/processors/test_sphinx.py
@@ -18,11 +18,13 @@ docstring_with_codeblocks = \
       d()
       with e() as f:
         f()
+  :return: A value
   '''
 
 md_with_codeblocks = \
   '''
   Code example:
+
   ```
   with a() as b:
     b()
@@ -33,6 +35,10 @@ md_with_codeblocks = \
       d()
       with e() as f:
         f()
+
+  **Returns**:
+
+  A value
   '''
 
 docstring_with_param_type_returns_rtype = \
@@ -123,6 +129,25 @@ md_with_raise = \
   
   - `KeyError`: A key is missing
   '''
+
+doc_with_multiline_param = \
+  '''
+  :param foolong: This parameter has a particularly long description
+  that requires multiple lines.
+  '''
+
+md_with_multiline_param = \
+  '''
+  **Arguments**:
+
+  - `foolong`: This parameter has a particularly long description
+  that requires multiple lines.
+  '''
+
+@pytest.mark.parametrize("processor", [SphinxProcessor(), SmartProcessor()])
+def test_sphinx_with_multiline_param(processor):
+  assert_processor_result(processor, doc_with_multiline_param, md_with_multiline_param)
+
 
 @pytest.mark.parametrize("processor", [SphinxProcessor(), SmartProcessor()])
 @pytest.mark.parametrize("keyword", ["arg", "argument", "param", "parameter"])


### PR DESCRIPTION
This is a proposal for a way to fix the issue with multi-line docstrings. This adds a dependency for docstring_parser and uses that to do the docstring parsing. That parser handles the multi-line docstrings already.

I'm not sure if you want to utilize that package or not.

I verified that this passes all the sphinx processor tests. There is one caveat. It seems like this adds a newline in the test for the codeblock example. I'm not sure if the changed behavior is acceptable or not. I've modified the test in this PR to account for that relatively minor change.

I'm open to any feedback regarding these changes.