### PR TITLE
Fixes error in bootstrap configuration

### DIFF
--- a/src/pydoc_markdown/static.py
+++ b/src/pydoc_markdown/static.py
@@ -50,7 +50,7 @@ renderer:
     - title: API Documentation
       children:
         - title: my_project
-          content: [ my_project, my_project.* ]
+          contents: [ my_project, my_project.* ]
   mkdocs_config:
     site_name: My Project
     theme: readthedocs
@@ -81,7 +81,7 @@ renderer:
     - title: API Documentation
       children:
         - title: my_project
-          content: [ my_project, my_project.* ]
+          contents: [ my_project, my_project.* ]
 '''.lstrip()
 
 DEFAULT_DOCUSAURUS_CONFIG = '''


### PR DESCRIPTION
Hi,

thank for this great tool!

I only just started using it. Tried using bootstrap config for mkdocs:

```bash
$ pydoc-markdown --bootstrap mkdocs
$ touch README.md
$ pydoc-markdown
[WARNING - pydoc_markdown.main]: Unknown configuration options: $.renderer.pages.1.children.content
```

I figured out there is a typo in the bootstrap configuration. Changing `content` to `contents` fixed the problem.