### PR TITLE
Add baseUrl param for hugo

### DIFF
--- a/.changelog/_unreleased.yml
+++ b/.changelog/_unreleased.yml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  component: hugo
+  description: 'Hugo now respects the baseUrl option @Heiss'

--- a/src/pydoc_markdown/contrib/renderers/hugo.py
+++ b/src/pydoc_markdown/contrib/renderers/hugo.py
@@ -327,6 +327,10 @@ class HugoRenderer(Renderer, Server, Builder):
   def start_server(self) -> subprocess.Popen:
     hugo_bin = self._get_hugo_bin()
     command = [hugo_bin, 'server', '--bind', self.config.serverURL, '--port', str(self.config.serverPort)]
+    
+    if self.config.baseURL is not None:
+        command.extend(["--baseUrl", self.get_server_url()])
+    
     logger.info('Running %s in "%s"', command, self.build_directory)
     return subprocess.Popen(command, cwd=self.build_directory)
 


### PR DESCRIPTION
Hey,

i saw, that the hugo renderer does not respect the baseUrl. So this PR integrates it in the hugo command. The `get_server_url` method handles this already, so the baseUrl is in fact a call of this method.

This makes it possible to specify a subdirectory or other hosts ip as localhost (which is now possible because of the latest update with serverURL and serverPort).