### PR TITLE
Implement cross-references across multiple pages [TEST]

### DIFF
--- a/src/pydoc_markdown/contrib/processors/filter.py
+++ b/src/pydoc_markdown/contrib/processors/filter.py
@@ -64,6 +64,9 @@ class FilterProcessor(Processor):
   #: Do not filter #docspec.Module objects. Default: `true`
   do_not_filter_modules: bool = True
 
+  #: Do not filter #docspec.Module objects. Default: `true`
+  do_not_filter_import: bool = True
+
   #: Skip modules with no content. Default: `false`.
   skip_empty_modules: bool = False
 
@@ -83,6 +86,8 @@ class FilterProcessor(Processor):
       if self.skip_empty_modules and isinstance(obj, docspec.Module) and not members:
         return False
       if self.do_not_filter_modules and isinstance(obj, docspec.Module):
+        return True
+      if self.do_not_filter_import and isinstance(obj, docspec.Indirection):
         return True
       if self.documented_only and not obj.docstring:
         return False

--- a/src/pydoc_markdown/contrib/renderers/hugo.py
+++ b/src/pydoc_markdown/contrib/renderers/hugo.py
@@ -315,8 +315,8 @@ class HugoRenderer(Renderer, Server, Builder):
 
   def get_resolver(self, modules: t.List[docspec.Module]) -> t.Optional[Resolver]:
     # TODO (@NiklasRosenstein): The resolver returned by the Markdown
-    #   renderer does not implement linking across multiple pages.
-    return self.markdown.get_resolver(modules)
+    #   HugoRenderer now has implemented linking across multiple pages.
+    return self.markdown.get_resolver(modules, self)
 
   # Server
 

--- a/src/pydoc_markdown/contrib/renderers/markdown.py
+++ b/src/pydoc_markdown/contrib/renderers/markdown.py
@@ -686,15 +686,12 @@ class MultiplePagesReferenceResolver(MarkdownReferenceResolver):
 
     if target_page == None or this_page == None: return None
 
-    parent_index = -1
-    while this_page[parent_index + 1].title == target_page[parent_index + 1].title:
+    for parent_index in range(len(this_page)):
+        if parent_index >= len(target_page): break
+        if this_page[parent_index].title != target_page[parent_index].title: break
 
-      parent_index += 1
-      if parent_index + 1 >= len(this_page) or parent_index + 1 >= len(target_page): break
-      
-    relative_index = len(this_page) - parent_index - 1
-    relative_path = "../" * relative_index
+    relative_path = "../" * (len(this_page) - parent_index)
 
-    url = relative_path + "/".join(page.title for page in target_page[parent_index+1:relative_index+1]) + "#" + target_id
+    url = relative_path + "/".join(page.title.replace(" ", "-") for page in target_page[parent_index:]) + "#" + target_id
     
     return url

--- a/src/pydoc_markdown/contrib/renderers/markdown.py
+++ b/src/pydoc_markdown/contrib/renderers/markdown.py
@@ -692,6 +692,6 @@ class MultiplePagesReferenceResolver(MarkdownReferenceResolver):
 
     relative_path = "../" * (len(this_page) - parent_index)
 
-    url = relative_path + "/".join(page.title.replace(" ", "-") for page in target_page[parent_index:]) + "#" + target_id
+    url = relative_path + "/".join(page.title.replace(" ", "-").lower() for page in target_page[parent_index:]) + "#" + target_id
     
     return url

--- a/src/pydoc_markdown/contrib/renderers/mkdocs.py
+++ b/src/pydoc_markdown/contrib/renderers/mkdocs.py
@@ -180,8 +180,8 @@ class MkdocsRenderer(Renderer, Server, Builder):
 
   def get_resolver(self, modules: List[docspec.Module]) -> Optional[Resolver]:
     # TODO (@NiklasRosenstein): The resolver returned by the Markdown
-    #   renderer does not implement linking across multiple pages.
-    return self.markdown.get_resolver(modules)
+    #   MkdocsRenderer now has implemented linking across multiple pages.
+    return self.markdown.get_resolver(modules, self)
 
   # Server
 


### PR DESCRIPTION
## Added a new Reference Resolver that now supports cross-referencing across all pages.

### Changes:
- Added a new resolver called `MultiplePagesReferenceResolver`
- Added `do_not_filter_import` to `class FilterProcessor` - this is because the new resolver uses `docspec.Indirection` to process imports and finds the reference

_Sorry for the ugly code_