### PR TITLE
Add Apple Silicon to architecture types

### DIFF
--- a/.changelog/_unreleased.yml
+++ b/.changelog/_unreleased.yml
@@ -6,3 +6,6 @@ changes:
   component: docusaurus
   description: 'Update `plugin-content-docs` config for docusarus@beta to not exclude files and folders with underscores. (@chrisstetter)'
   fixes: [ '#189' ]
+- type: fix  # or one of improvement, change, breaking_change, refactor, feature, docs, tests
+  component: hugo  # or docusaurus, hugo, markdown, or something else applicable
+  description: 'Adds Apple Silicon to Hugo's recognized architectures. (@MilesCranmer)'

--- a/.changelog/_unreleased.yml
+++ b/.changelog/_unreleased.yml
@@ -6,6 +6,6 @@ changes:
   component: docusaurus
   description: 'Update `plugin-content-docs` config for docusarus@beta to not exclude files and folders with underscores. (@chrisstetter)'
   fixes: [ '#189' ]
-- type: fix  # or one of improvement, change, breaking_change, refactor, feature, docs, tests
-  component: hugo  # or docusaurus, hugo, markdown, or something else applicable
+- type: fix
+  component: hugo
   description: 'Adds Apple Silicon to Hugo's recognized architectures. (@MilesCranmer)'

--- a/src/pydoc_markdown/contrib/renderers/hugo.py
+++ b/src/pydoc_markdown/contrib/renderers/hugo.py
@@ -371,7 +371,7 @@ def install_hugo(to: str, version: str = None, extended: bool = True) -> None:
     raise EnvironmentError('unsure how to get a Hugo binary for platform {!r}'.format(sys.platform))
 
   machine = _platform.machine().lower()
-  if machine in ('x86_64', 'amd64'):
+  if machine in ('x86_64', 'amd64', 'arm64'):
     arch = '64bit'
   elif machine in ('i386',):
     arch = '32bit'


### PR DESCRIPTION
Adds 'arm64' to architecture types for 64-bit.