### PR TITLE
improvement: Implement support for NumPy-style docstrings

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,8 @@
+[[entries]]
+id = "5be79248-7b86-465d-953c-d0c69ab64e8a"
+type = "improvement"
+description = "Implement support for NumPy-style docstrings"
+author = "celsiusnarhwal"
+issues = [
+    "https://github.com/celsiusnarhwal/pydoc-markdown/issues/251",
+]

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,6 +3,7 @@ id = "5be79248-7b86-465d-953c-d0c69ab64e8a"
 type = "improvement"
 description = "Implement support for NumPy-style docstrings"
 author = "celsiusnarhwal"
+pr = "https://github.com/NiklasRosenstein/pydoc-markdown/pull/279"
 issues = [
     "https://github.com/celsiusnarhwal/pydoc-markdown/issues/251",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ tomli = "^2.0.0"
 tomli_w = "^1.0.0"
 yapf = ">=0.30.0"
 watchdog = "*"
+numpydoc = "^1.5.0"
 
 [tool.poetry.urls]
 Homepage = "https://github.com/NiklasRosenstein/pydoc-markdown"

--- a/readme.md
+++ b/readme.md
@@ -35,8 +35,8 @@ YAML configuration, you should install the package directly through Pipx.
 
 ### Features
 
-* Understands multiple documentation styles (Sphinx, Google, Pydoc-Markdown specific) and converts them to properly
-  formatted Markdown
+* Understands multiple documentation styles (Sphinx, Google, NumPy, Pydoc-Markdown specific) and converts them to 
+  properly formatted Markdown
 * Can parse docstrings for variables thanks to [docspec][] (`#:` block before or string literal after the statement)
 * Generates links to other API objects per the documentation syntax (e.g. `#OtherClass` for the Pydoc-Markdown style)
 

--- a/src/pydoc_markdown/contrib/processors/numpy.py
+++ b/src/pydoc_markdown/contrib/processors/numpy.py
@@ -125,7 +125,9 @@ class NumpyProcessor(Processor):
             except Warning:
                 return False
 
-    def process(self, modules: t.List[docspec.Module], resolver: t.Optional[Resolver]) -> None:
+    def process(
+        self, modules: t.List[docspec.Module], resolver: t.Optional[Resolver]
+    ) -> None:
         docspec.visit(modules, self._process)
 
     def _process(self, node: docspec.ApiObject):
@@ -136,7 +138,11 @@ class NumpyProcessor(Processor):
         lines = []
 
         # Filter self._SECTION_MAP to only include sections used in the docstring
-        active_sections = {k: v for k, v in self._SECTION_MAP.items() if any(docstring.get(sec) for sec in v)}
+        active_sections = {
+            k: v
+            for k, v in self._SECTION_MAP.items()
+            if any(docstring.get(sec) for sec in v)
+        }
 
         # numpydoc is opinionated when it comes to section order so we have to preserve the order of the original
         # docstring ourselves
@@ -144,29 +150,42 @@ class NumpyProcessor(Processor):
         # First, we create a regex pattern to match all section headings in the docstring
         keyword_regex = re.compile(
             "|".join(
-                [rf"{keyword}(?:\r?\n)-{{{len(keyword)}}}" for keyword in itertools.chain(*active_sections.values())]
+                [
+                    rf"{keyword}(?:\r?\n)-{{{len(keyword)}}}"
+                    for keyword in itertools.chain(*active_sections.values())
+                ]
             )
         )
 
         # Second, we strip each patten match of hyphens and whitespace
-        keyword_matches = [match.replace("-", "").strip() for match in keyword_regex.findall(node.docstring.content)]
+        keyword_matches = [
+            match.replace("-", "").strip()
+            for match in keyword_regex.findall(node.docstring.content)
+        ]
 
         # Third, we determine the section order in the eventual output based on the order of the headings in the
         # original docstring (but always starting with the summary)
         section_order = [
             "Summary",
-            *[next(key for key, value in active_sections.items() if keyword in value) for keyword in keyword_matches],
+            *[
+                next(key for key, value in active_sections.items() if keyword in value)
+                for keyword in keyword_matches
+            ],
         ]
 
         # Finally, we sort active_sections according to the section order we just determined
-        sorted_sections = sorted(active_sections.items(), key=lambda x: section_order.index(x[0]))
+        active_sections = sorted(
+            active_sections.items(), key=lambda x: section_order.index(x[0])
+        )
 
-        for section, keywords in sorted_sections:
+        for section, keywords in active_sections:
             lines.extend(self._get_section_contents(docstring, section, keywords))
 
         node.docstring.content = "\n".join(lines)
 
-    def _get_section_contents(self, docstring: NumpyDocString, section: str, keywords: list) -> list[str]:
+    def _get_section_contents(
+        self, docstring: NumpyDocString, section: str, keywords: list
+    ) -> list[str]:
         contents = list(itertools.chain([docstring.get(sec) for sec in keywords]))
 
         if section == "Summary":
@@ -224,7 +243,9 @@ class NumpyProcessor(Processor):
 
         for match in citations.finditer(contents):
             ref_id = match.group("ref_id")
-            contents = contents.replace(match.group(0), replacements[section].format(ref_id=ref_id))
+            contents = contents.replace(
+                match.group(0), replacements[section].format(ref_id=ref_id)
+            )
 
         return [f"\n**{section}**\n", *contents.splitlines()]
 
@@ -232,7 +253,10 @@ class NumpyProcessor(Processor):
     def _parse_examples(contents: list[str]) -> list[str]:
         # Wraps doctests in Python codeblocks and leaves all other content as is
         doctests = re.compile(r"(>>>(?:.+(?:\r?\n|$))+)", flags=re.MULTILINE)
-        return ["\n**Examples**\n", *doctests.sub("```python\n\g<0>\n```", "\n".join(contents)).splitlines()]
+        return [
+            "\n**Examples**\n",
+            *doctests.sub("```python\n\g<0>\n```", "\n".join(contents)).splitlines(),
+        ]
 
     @staticmethod
     def _parse_see_also(contents: list[tuple]) -> list[str]:
@@ -242,10 +266,16 @@ class NumpyProcessor(Processor):
             sublines = []
             objs, desc = group
 
-            sublines.append("* " + ", ".join([f":{obj[1]}:`{obj[0]}`" if obj[1] else f"{obj[0]}" for obj in objs]))
+            sublines.append(
+                "* "
+                + ", ".join(
+                    [f":{obj[1]}:`{obj[0]}`" if obj[1] else f"{obj[0]}" for obj in objs]
+                )
+            )
 
             if desc:
                 sublines[-1] += ": " + "\n".join(desc)
+
             lines.extend(sublines)
 
         return [f"\n**See Also**\n", *lines]

--- a/src/pydoc_markdown/contrib/processors/numpy.py
+++ b/src/pydoc_markdown/contrib/processors/numpy.py
@@ -19,6 +19,8 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+from __future__ import annotations
+
 import dataclasses
 import itertools
 import re
@@ -27,14 +29,14 @@ import warnings
 from contextlib import contextmanager
 
 import docspec
-from numpydoc.docscrape import NumpyDocString, Parameter
-from numpydoc.validate import validate
+from numpydoc.docscrape import NumpyDocString, Parameter  # type: ignore[import]
+from numpydoc.validate import validate  # type: ignore[import]
 
 from pydoc_markdown.interfaces import Processor, Resolver
 
 
 @contextmanager
-def _filter_numpydoc_warnings(action: str):
+def _filter_numpydoc_warnings(action: warnings._ActionKind):
     warnings.filterwarnings(action, module="numpydoc.docscrape")
     yield
     warnings.resetwarnings()
@@ -159,9 +161,7 @@ class NumpyProcessor(Processor):
         ]
 
         # Finally, we sort active_sections according to the section order we just determined
-        active_sections = sorted(active_sections.items(), key=lambda x: section_order.index(x[0]))
-
-        for section, keywords in active_sections:
+        for section, keywords in sorted(active_sections.items(), key=lambda x: section_order.index(x[0])):
             lines.extend(self._get_section_contents(docstring, section, keywords))
 
         node.docstring.content = "\n".join(lines)
@@ -217,16 +217,16 @@ class NumpyProcessor(Processor):
 
     @staticmethod
     def _parse_notes_and_references(section: str, contents: list[str]) -> list[str]:
-        contents = "\n".join(contents)
+        content_string = "\n".join(contents)
         citations = re.compile("(\.\. )?\[(?P<ref_id>\w+)][_ ]?")
 
         replacements = {"Notes": "<sup>{ref_id}</sup>", "References": "{ref_id}. "}
 
-        for match in citations.finditer(contents):
+        for match in citations.finditer(content_string):
             ref_id = match.group("ref_id")
-            contents = contents.replace(match.group(0), replacements[section].format(ref_id=ref_id))
+            content_string = content_string.replace(match.group(0), replacements[section].format(ref_id=ref_id))
 
-        return [f"\n**{section}**\n", *contents.splitlines()]
+        return [f"\n**{section}**\n", *content_string.splitlines()]
 
     @staticmethod
     def _parse_examples(contents: list[str]) -> list[str]:

--- a/src/pydoc_markdown/contrib/processors/numpy.py
+++ b/src/pydoc_markdown/contrib/processors/numpy.py
@@ -1,0 +1,251 @@
+# -*- coding: utf8 -*-
+# Copyright (c) 2019 Niklas Rosenstein
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+import dataclasses
+import itertools
+import re
+import typing as t
+import warnings
+from contextlib import contextmanager
+
+import docspec
+from numpydoc.docscrape import NumpyDocString, Parameter
+from numpydoc.validate import validate
+
+from pydoc_markdown.interfaces import Processor, Resolver
+
+
+@contextmanager
+def _filter_numpydoc_warnings(action: str):
+    warnings.filterwarnings(action, module="numpydoc.docscrape")
+    yield
+    warnings.resetwarnings()
+
+
+class _DocstringWrapper:
+    # Wraps docstrings for use with numpydoc.validate.validate().
+    __qualname__ = "pydoc_markdown.contrib.processors.numpy._DocstringWrapper"
+
+
+@dataclasses.dataclass
+class NumpyProcessor(Processor):
+    # numpydoc doesn't like when a heading appears twice in the same docstring so we have to use <span> tags to
+    # keep numpydoc from recognizing the example headings. This also means the example code block has to be
+    # delineated with HTML tags instead of Markdown syntax.
+    """
+    This processor parses NumPy-style docstrings and converts them to Markdown syntax.
+
+    References
+    ----------
+    - https://numpydoc.readthedocs.io/en/latest/format.html
+
+    Examples
+    --------
+    <pre>
+    <code>
+    <span>Parameters</span>
+    ----------
+    arg: str
+        This argument should be a string.
+
+    <span>Raises</span>
+    ------
+    ValueError
+        If *arg* is not a string.
+
+    <span>Returns</span>
+    -------
+    int
+        The length of the string.
+    </code>
+    </pre>
+
+    Renders as:
+
+    Parameters
+    ----------
+    arg : str
+        This argument should be a string.
+
+    Raises
+    ------
+    ValueError
+        If *arg* is not a string.
+
+    Returns
+    -------
+    int
+        The length of the string.
+
+    @doc:fmt:numpy
+    """
+
+    _SECTION_MAP = {
+        "Summary": ["Summary", "Extended Summary"],
+        "Arguments": ["Parameters", "Other Parameters"],
+        "Returns": ["Returns"],
+        "Yields": ["Yields"],
+        "Receives": ["Receives"],
+        "Attributes": ["Attributes"],
+        "Methods": ["Methods"],
+        "Raises": ["Raises"],
+        "Warns": ["Warns"],
+        "Warnings": ["Warnings"],
+        "See Also": ["See Also"],
+        "Notes": ["Notes"],
+        "References": ["References"],
+        "Examples": ["Examples"],
+    }
+
+    @staticmethod
+    def check_docstring_format(docstring: str) -> bool:
+        _DocstringWrapper.__doc__ = docstring
+
+        with _filter_numpydoc_warnings("error"):
+            try:
+                return not validate(_DocstringWrapper.__qualname__).get("Errors")
+            except Warning:
+                return False
+
+    def process(self, modules: t.List[docspec.Module], resolver: t.Optional[Resolver]) -> None:
+        docspec.visit(modules, self._process)
+
+    def _process(self, node: docspec.ApiObject):
+        if not node.docstring:
+            return
+
+        docstring = NumpyDocString(node.docstring.content)
+        lines = []
+
+        # Filter self._SECTION_MAP to only include sections used in the docstring
+        active_sections = {k: v for k, v in self._SECTION_MAP.items() if any(docstring.get(sec) for sec in v)}
+
+        # numpydoc is opinionated when it comes to section order so we have to preserve the order of the original
+        # docstring ourselves
+
+        # First, we create a regex pattern to match all section headings in the docstring
+        keyword_regex = re.compile(
+            "|".join(
+                [rf"{keyword}(?:\r?\n)-{{{len(keyword)}}}" for keyword in itertools.chain(*active_sections.values())]
+            )
+        )
+
+        # Second, we strip each patten match of hyphens and whitespace
+        keyword_matches = [match.replace("-", "").strip() for match in keyword_regex.findall(node.docstring.content)]
+
+        # Third, we determine the section order in the eventual output based on the order of the headings in the
+        # original docstring (but always starting with the summary)
+        section_order = [
+            "Summary",
+            *[next(key for key, value in active_sections.items() if keyword in value) for keyword in keyword_matches],
+        ]
+
+        # Finally, we sort active_sections according to the section order we just determined
+        sorted_sections = sorted(active_sections.items(), key=lambda x: section_order.index(x[0]))
+
+        for section, keywords in sorted_sections:
+            lines.extend(self._get_section_contents(docstring, section, keywords))
+
+        node.docstring.content = "\n".join(lines)
+
+    def _get_section_contents(self, docstring: NumpyDocString, section: str, keywords: list) -> list[str]:
+        contents = list(itertools.chain([docstring.get(sec) for sec in keywords]))
+
+        if section == "Summary":
+            return self._parse_summary(contents)
+        else:
+            # contents needs to be flattened for all sections aside from Summary
+            contents = list(itertools.chain(*contents))
+            if section in ["Notes", "References"]:
+                return self._parse_notes_and_references(section, contents)
+            elif section == "Examples":
+                return self._parse_examples(contents)
+            elif section == "See Also":
+                return self._parse_see_also(contents)
+            elif any(isinstance(item, Parameter) for item in contents):
+                return self._parse_parameters(section, contents)
+            else:
+                return [f"\n**{section}**\n", *contents] if contents else []
+
+    @staticmethod
+    def _parse_summary(contents: list[str]) -> list[str]:
+        summary, extended = contents
+        return [*summary, "", *extended] if extended else [*summary]
+
+    @staticmethod
+    def _parse_parameters(section: str, parameters: list[Parameter]) -> list[str]:
+        lines = []
+
+        for param in parameters:
+            name, cls, desc = param
+            desc = "\n".join(desc)
+
+            if name and cls and desc:
+                lines.append(f"* **{name}** (`{cls}`): {desc}")
+            elif name and cls:
+                lines.append(f"* **{name}** (`{cls}`)")
+            elif name and desc:
+                lines.append(f"* **{name}**: {desc}")
+            elif cls and desc:
+                lines.append(f"* `{cls}`: {desc}")
+            elif name:
+                lines.append(f"* **{name}**")
+            elif cls:
+                lines.append(f"* `{cls}`")
+            elif desc:
+                lines.append(f"* {desc}")
+
+        return [f"\n**{section}**\n", *lines] if lines else []
+
+    @staticmethod
+    def _parse_notes_and_references(section: str, contents: list[str]) -> list[str]:
+        contents = "\n".join(contents)
+        citations = re.compile("(\.\. )?\[(?P<ref_id>\w+)][_ ]?")
+
+        replacements = {"Notes": "<sup>{ref_id}</sup>", "References": "{ref_id}. "}
+
+        for match in citations.finditer(contents):
+            ref_id = match.group("ref_id")
+            contents = contents.replace(match.group(0), replacements[section].format(ref_id=ref_id))
+
+        return [f"\n**{section}**\n", *contents.splitlines()]
+
+    @staticmethod
+    def _parse_examples(contents: list[str]) -> list[str]:
+        # Wraps doctests in Python codeblocks and leaves all other content as is
+        doctests = re.compile(r"(>>>(?:.+(?:\r?\n|$))+)", flags=re.MULTILINE)
+        return ["\n**Examples**\n", *doctests.sub("```python\n\g<0>\n```", "\n".join(contents)).splitlines()]
+
+    @staticmethod
+    def _parse_see_also(contents: list[tuple]) -> list[str]:
+        lines = []
+
+        for group in contents:
+            sublines = []
+            objs, desc = group
+
+            sublines.append("* " + ", ".join([f":{obj[1]}:`{obj[0]}`" if obj[1] else f"{obj[0]}" for obj in objs]))
+
+            if desc:
+                sublines[-1] += ": " + "\n".join(desc)
+            lines.extend(sublines)
+
+        return [f"\n**See Also**\n", *lines]

--- a/src/pydoc_markdown/contrib/processors/numpy.py
+++ b/src/pydoc_markdown/contrib/processors/numpy.py
@@ -125,9 +125,7 @@ class NumpyProcessor(Processor):
             except Warning:
                 return False
 
-    def process(
-        self, modules: t.List[docspec.Module], resolver: t.Optional[Resolver]
-    ) -> None:
+    def process(self, modules: t.List[docspec.Module], resolver: t.Optional[Resolver]) -> None:
         docspec.visit(modules, self._process)
 
     def _process(self, node: docspec.ApiObject):
@@ -138,11 +136,7 @@ class NumpyProcessor(Processor):
         lines = []
 
         # Filter self._SECTION_MAP to only include sections used in the docstring
-        active_sections = {
-            k: v
-            for k, v in self._SECTION_MAP.items()
-            if any(docstring.get(sec) for sec in v)
-        }
+        active_sections = {k: v for k, v in self._SECTION_MAP.items() if any(docstring.get(sec) for sec in v)}
 
         # numpydoc is opinionated when it comes to section order so we have to preserve the order of the original
         # docstring ourselves
@@ -150,42 +144,29 @@ class NumpyProcessor(Processor):
         # First, we create a regex pattern to match all section headings in the docstring
         keyword_regex = re.compile(
             "|".join(
-                [
-                    rf"{keyword}(?:\r?\n)-{{{len(keyword)}}}"
-                    for keyword in itertools.chain(*active_sections.values())
-                ]
+                [rf"{keyword}(?:\r?\n)-{{{len(keyword)}}}" for keyword in itertools.chain(*active_sections.values())]
             )
         )
 
         # Second, we strip each patten match of hyphens and whitespace
-        keyword_matches = [
-            match.replace("-", "").strip()
-            for match in keyword_regex.findall(node.docstring.content)
-        ]
+        keyword_matches = [match.replace("-", "").strip() for match in keyword_regex.findall(node.docstring.content)]
 
         # Third, we determine the section order in the eventual output based on the order of the headings in the
         # original docstring (but always starting with the summary)
         section_order = [
             "Summary",
-            *[
-                next(key for key, value in active_sections.items() if keyword in value)
-                for keyword in keyword_matches
-            ],
+            *[next(key for key, value in active_sections.items() if keyword in value) for keyword in keyword_matches],
         ]
 
         # Finally, we sort active_sections according to the section order we just determined
-        active_sections = sorted(
-            active_sections.items(), key=lambda x: section_order.index(x[0])
-        )
+        active_sections = sorted(active_sections.items(), key=lambda x: section_order.index(x[0]))
 
         for section, keywords in active_sections:
             lines.extend(self._get_section_contents(docstring, section, keywords))
 
         node.docstring.content = "\n".join(lines)
 
-    def _get_section_contents(
-        self, docstring: NumpyDocString, section: str, keywords: list
-    ) -> list[str]:
+    def _get_section_contents(self, docstring: NumpyDocString, section: str, keywords: list) -> list[str]:
         contents = list(itertools.chain([docstring.get(sec) for sec in keywords]))
 
         if section == "Summary":
@@ -243,9 +224,7 @@ class NumpyProcessor(Processor):
 
         for match in citations.finditer(contents):
             ref_id = match.group("ref_id")
-            contents = contents.replace(
-                match.group(0), replacements[section].format(ref_id=ref_id)
-            )
+            contents = contents.replace(match.group(0), replacements[section].format(ref_id=ref_id))
 
         return [f"\n**{section}**\n", *contents.splitlines()]
 
@@ -266,12 +245,7 @@ class NumpyProcessor(Processor):
             sublines = []
             objs, desc = group
 
-            sublines.append(
-                "* "
-                + ", ".join(
-                    [f":{obj[1]}:`{obj[0]}`" if obj[1] else f"{obj[0]}" for obj in objs]
-                )
-            )
+            sublines.append("* " + ", ".join([f":{obj[1]}:`{obj[0]}`" if obj[1] else f"{obj[0]}" for obj in objs]))
 
             if desc:
                 sublines[-1] += ": " + "\n".join(desc)

--- a/src/pydoc_markdown/contrib/processors/pydocmd.py
+++ b/src/pydoc_markdown/contrib/processors/pydocmd.py
@@ -73,7 +73,7 @@ class PydocmdProcessor(Processor):
     def process(self, modules: t.List[docspec.Module], resolver: t.Optional[Resolver]) -> None:
         docspec.visit(modules, self._process)
 
-    def _process(self, node: docspec.ApiObject):
+    def _process(self, node: docspec.ApiObject) -> None:
         if not node.docstring:
             return
         lines = []

--- a/src/pydoc_markdown/contrib/processors/smart.py
+++ b/src/pydoc_markdown/contrib/processors/smart.py
@@ -20,15 +20,29 @@
 # IN THE SOFTWARE.
 
 import dataclasses
+import logging
 import typing as t
 
 import docspec
+from typing_extensions import Protocol
 
 from pydoc_markdown.contrib.processors.google import GoogleProcessor
 from pydoc_markdown.contrib.processors.numpy import NumpyProcessor
 from pydoc_markdown.contrib.processors.pydocmd import PydocmdProcessor
 from pydoc_markdown.contrib.processors.sphinx import SphinxProcessor
 from pydoc_markdown.interfaces import Processor, Resolver
+
+logger = logging.getLogger(__name__)
+
+
+class DelegatableProcessor(Protocol):
+    def _process(self, node: docspec.ApiObject) -> None:
+        ...
+
+
+class CheckCapableProcessor(DelegatableProcessor, Protocol):
+    def check_docstring_format(self, docstring: str) -> bool:
+        ...
 
 
 @dataclasses.dataclass
@@ -50,16 +64,33 @@ class SmartProcessor(Processor):
         if not obj.docstring:
             return None
 
-        for name in ("google", "pydocmd", "sphinx", "numpy"):
+        object_name = ".".join(x.name for x in obj.path)
+        object_type = type(obj).__name__
+
+        processors: t.List[t.Tuple[str, DelegatableProcessor]] = [
+            ("sphinx", self.sphinx),
+            ("google", self.google),
+            ("numpy", self.numpy),
+            ("pydocmd", self.pydocmd),
+        ]
+
+        checkable_processors: t.List[t.Tuple[str, CheckCapableProcessor]] = [
+            ("sphinx", self.sphinx),
+            ("google", self.google),
+            ("numpy", self.numpy),
+        ]
+
+        for name, processor in processors:
             indicator = "@doc:fmt:" + name
             if indicator in obj.docstring.content:
+                logger.info("Using `%s` processor for %s `%s` (explicit)", name, object_type, object_name)
                 obj.docstring.content = obj.docstring.content.replace(indicator, "")
-                return getattr(self, name)._process(obj)
+                return processor._process(obj)
 
-        if self.sphinx.check_docstring_format(obj.docstring.content):
-            return self.sphinx._process(obj)
-        if self.google.check_docstring_format(obj.docstring.content):
-            return self.google._process(obj)
-        if self.numpy.check_docstring_format(obj.docstring.content):
-            return self.numpy._process(obj)
+        for name, processor in checkable_processors:
+            if processor.check_docstring_format(obj.docstring.content):
+                logger.info("Using `%s` processor for %s `%s` (detected)", name, object_type, object_name)
+                return processor._process(obj)
+
+        logger.info("Using `pydocmd` processor for %s `%s` (default)", name, object_type, object_name)
         return self.pydocmd._process(obj)

--- a/test/processors/__init__.py
+++ b/test/processors/__init__.py
@@ -11,4 +11,5 @@ def assert_processor_result(processor, docstring, expected_output):
     )
     processor.process([module], None)
     assert module.docstring
+    print(module.docstring.content)
     assert_text_equals(module.docstring.content, textwrap.dedent(expected_output))

--- a/test/processors/test_numpy.py
+++ b/test/processors/test_numpy.py
@@ -1,0 +1,118 @@
+import pytest
+
+from pydoc_markdown.contrib.processors.numpy import NumpyProcessor
+from . import assert_processor_result
+
+docstring_a = """
+    Generate ordinary dialogue.
+    
+    Extended Summary
+    ----------------
+    This function generates ordinary dialogue so that users can fully enjoy how efficient the code is.
+    
+    Parameters
+    ----------
+    lines : int
+        The number of lines of dialogue to generate.
+    
+    Returns
+    -------
+    list[str]
+        The generated lines of dialogue.
+    
+    Raises
+    ------
+    ValueError
+        If *lines* is not a positive integer.
+    
+    Examples
+    --------
+    >>> ordinary_dialogue(5)
+    ["You should just read this manga as is.",
+    "Why would anyone want to make an anime adaptation?",
+    "This is a dialogue-heavy piece with hardly any action.",
+    "Not to mention most of it takes place in a dressing room.",
+    "So why would anyone turn a manga like this into an anime?"]
+    """
+
+md_docstring_a = """
+    Generate ordinary dialogue.
+    
+    This function generates ordinary dialogue so that users can fully enjoy how efficient the code is.
+    
+    **Arguments**
+    
+    * **lines** (`int`): The number of lines of dialogue to generate.
+    
+    **Returns**
+    
+    * `list[str]`: The generated lines of dialogue.
+    
+    **Raises**
+    
+    * `ValueError`: If *lines* is not a positive integer.
+    
+    **Examples**
+    
+    ```python
+    >>> ordinary_dialogue(5)
+    ["You should just read this manga as is.",
+    "Why would anyone want to make an anime adaptation?",
+    "This is a dialogue-heavy piece with hardly any action.",
+    "Not to mention most of it takes place in a dressing room.",
+    "So why would anyone turn a manga like this into an anime?"]
+    ```
+    """
+
+docstring_b = """
+    Shout "You fool!".
+    
+    Notes
+    -----
+    The average "You fool!" travels at 340 m/s[1]_.
+    
+    References
+    ----------
+    .. [1] Tsutomu Mizushima (Director). (2012, July 5). Normal Dialogue / Different Clothes / Shouting Instructions 
+    (No. 1). In Joshiraku. Mainichi Broadcasting System.
+    
+    Examples
+    --------
+    >>> you_fool()
+    "You fool!"
+    
+    See Also
+    --------
+    :func:`bakayarou`
+        The same function but in Japanese for no reason in particular.
+    """
+
+md_docstring_b = """
+    Shout "You fool!".
+    
+    **Notes**
+    
+    The average "You fool!" travels at 340 m/s<sup>1</sup>.
+    
+    **References**
+    
+    1. Tsutomu Mizushima (Director). (2012, July 5). Normal Dialogue / Different Clothes / Shouting Instructions
+    (No. 1). In Joshiraku. Mainichi Broadcasting System.
+    
+    **Examples**
+    
+    ```python
+    >>> you_fool()
+    "You fool!"
+    ``` 
+    
+    **See Also**
+    
+    * :func:`bakayarou`: The same function but in Japanese for no reason in particular.
+    """
+
+
+@pytest.mark.parametrize("processor", [NumpyProcessor()])
+def test_numpy_processor(processor):
+    assert_processor_result(processor or NumpyProcessor(), docstring_a, md_docstring_a)
+    assert_processor_result(processor or NumpyProcessor(), docstring_b, md_docstring_b)

--- a/test/processors/test_numpy.py
+++ b/test/processors/test_numpy.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pydoc_markdown.contrib.processors.numpy import NumpyProcessor
+
 from . import assert_processor_result
 
 docstring_a = """


### PR DESCRIPTION
This PR implements support for [NumPy-style docstrings](https://numpydoc.readthedocs.io/en/latest/format.html) via the new [`NumpyProcessor`](https://github.com/celsiusnarhwal/pydoc-markdown/blob/develop/src/pydoc_markdown/contrib/processors/numpy.py) class. It does so with the help of the [numpydoc](https://github.com/numpy/numpydoc) package, on which this PR makes Pydoc-Markdown dependent.

In addition to the above, this PR:
- Adds a [unit test](https://github.com/celsiusnarhwal/pydoc-markdown/blob/develop/test/processors/test_numpy.py) for `NumpyProcessor`
- Updates [`SmartProcessor`](https://github.com/celsiusnarhwal/pydoc-markdown/blob/develop/src/pydoc_markdown/contrib/processors/smart.py) to support `NumpyProcessor`
-  Updates [`pyproject.toml`](https://github.com/celsiusnarhwal/pydoc-markdown/blob/develop/pyproject.toml) to reflect the addition of numpydoc as a dependency
- Updates [`readme.md`](https://github.com/celsiusnarhwal/pydoc-markdown/blob/develop/readme.md) to reflect the addition of NumPy-style docstring support

This PR resolves #251.

### Caveats and Limitations

-  `NumpyProcessor.check_docstring_format()` returns `True` if a docstring passes [numpydoc's docstring validator](https://github.com/numpy/numpydoc/blob/fe95e8b9332ed4ebc154db08b00232f5f67f9330/numpydoc/validate.py#L453) without warnings or errors and `False` otherwise. Because `SmartProcessor` skips the call to `check_docstring_format` if the format is explicitly indicated in the docstring (e.g., with `@doc:fmt:numpy`), a docstring that would fail numpydoc's validator but nonetheless explicitly identifies itself as a NumPy-style docstring may result in warnings or exceptions at processing time.
    - The processor converts docstrings to [`NumpyDocString`](https://github.com/numpy/numpydoc/blob/fe95e8b9332ed4ebc154db08b00232f5f67f9330/numpydoc/docscrape.py#L118) objects before converting them to Markdown syntax. Instantiating a `NumpyDocString` object with an invalid docstring *will* result in warnings or exceptions. 
- Reference indexes in a docstring's Notes section are not hyperlinked to their corresponding references in the References section, in contrast to the [numpydoc spec](https://numpydoc.readthedocs.io/en/latest/format.html#references). This is due to what is apparently a behavior of Pydoc-Markdown's existing faculties, which insisted on rendering HTML tags in a way that broke the hyperlinks in all my attempts to implement this behavior. Examples of how reference indexes and references are rendered by `NumpyProcessor` can be found below.

## Examples

Here are examples of how the various sections of a NumPy-Style docstring are rendered by `NumpyProcessor`.

<details>
<summary>Summary / Extended Summary</summary>

The Summary and Extended Summary are rendered together as a single summary.

### Input

```
Decode a string by shifting each character by a given offset.

Extended Summary
----------------
There's not much else to say about this function, but if there was, it would go here. Fun fact: you 
don't need to include the Extended Summary heading — if your summary spans multiple lines, everything after the 
first will be implicitly considered to be the Extended Summary. You can't have both an implicit *and* explicit 
Extended Summary, though — that causes an exception!
```

### Output

Decode a string by shifting each character by a given offset.

There's not much else to say about this function, but if there was, it would go here. Fun fact: you don't need to include the Extended Summary heading — if your summary spans multiple lines, everything after the first will be implicitly considered to be the Extended Summary. You can't have both an implicit *and* explicit Extended Summary, though — that causes an exception!

</details>

<details>
<summary>Parameters / Other Parameters / Attributes / Recieves</summary>

The Parameters, Other Parameters, Attributes, and Receives sections are all rendered similarly.

### Input

```
Parameters
----------
string : str
    The string to decode.
   
Other Parameters
----------------
offset : int
    The offset by which to shift each character in the string. Defaults to 13.
    
Attributes
----------
attr : Any
    Functions don't have attributes, but if we were documenting a class, we'd put its attributes here. 
    Unfortunately, we are not. Too bad!
    
Receives
--------
param : Any
    If this was a generator, we'd document the parameters passed to it's `send()` method here.
    Unfortunately, it is not. Too bad!
```

### Output

**Arguments**

* **string** (`str`): The string to decode.
* **offset** (`int`): The offset by which to shift each character in the string. Defaults to 13.

**Attributes**

* **attr** (`Any`): Functions don't have attributes, but if we were documenting a class, we'd put its attributes here. Unfortunately, we are not. Too bad!

**Receives**

* **param** (`Any`): If this was a generator, we'd document the parameters passed to it's `send()` method here. Unfortunately, it is not. Too bad!

</details>

<details>
<summary>Returns / Yields</summary>

The Returns and Yields sections are rendered similarly.

### Input

```
Returns
-------
str
    The decoded string.

Yields
------
char : str
    The decoded string, one character at a time. By the way, you can optionally annotate your return and yield 
    values with names like I did here. The type annotation isn't optional, though.
```

### Output

**Returns**

* `str`: The decoded string.

**Yields**

* **char** (`str`): The decoded string, one character at a time. By the way, you can optionally annotate your return and yield values with names like I did here. The type annotation isn't optional, though.



</details>

<details>
<summary>Raises / Warns</summary>

The Raises and Warns sections are rendered similarly.

### Input

```
Raises
------
ValueError
    If the string contains non-alphabetic characters.

Warns
-----
UserWarning
    If I don't like you.
```

### Output

**Raises**

* `ValueError`: If the string contains non-alphabetic characters.

**Warns**

* `UserWarning`: If I don't like you.

</details>

<details>
<summary>See Also</summary>

### Input

```
See Also
--------
:func:`encode`
    Encode a string by shifting each character by a given offset.
```
### Output

**See Also**

* :func:\`encode\`: Encode a string by shifting each character by a given offset.

*(The processor leaves the task of cross-referencing functions, classes, and methods in this section to Pydoc-Markdown's existing faculties.)*

</details>

<details>
<summary>Notes</summary>

### Input

```
Notes
-----
This function implements an inverse substitution cipher[1]_.
```

### Output

**Notes**

This function implements an inverse substitution cipher<sup>1</sup>.

</details>

<details>
<summary>References</summary>

### Input

```
References
----------
.. [1] https://en.wikipedia.org/wiki/Substitution_cipher
```

### Output

**References**

1. https://en.wikipedia.org/wiki/Substitution_cipher

</details>

<details>
<summary>Examples</summary>

The Examples section supports [doctests](https://docs.python.org/3/library/doctest.html). The processor renders doctests in code blocks and other content as plain text.

The processor considers the start of a doctest to be marked by a line beginning with `>>>` and the end of a doctest to be marked by a blank line. If multiple doctests are present, they are rendered in separate code blocks.

### Input

```
Examples
--------
>>> decode("Qba'g nfx fghcvq dhrfgvbaf!")
"Don't ask stupid questions!"

This is a super simple function so I don't really know why you'd need more than one example but here's another one 
anyway.

>>> decode("Gunax lbh xvaqyl sbe lbhe nggragvba!")
"Thank you kindly for your attention!"
```

### Output

**Examples**

```python
>>> decode("Qba'g nfx fghcvq dhrfgvbaf!")
"Don't ask stupid questions!"
```

This is a super simple function so I don't really know why you'd need more than one example but here's another one anyway.

```python
>>> decode("Gunax lbh xvaqyl sbe lbhe nggragvba!")
"Thank you kindly for your attention!"
```