### PR TITLE
Adds Support for Nextra Configuration

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "95961813-2008-4677-836b-4bc3b30d38b5"
+type = "improvement"
+description = "Adds Nextra support"
+author = "ian.k.eaves@gmail.com"

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ If you want to talk about a potential contribution before investing any time, pl
 
 ## Changelog entries
 
-Pydoc-Markdown uses [Slap][] to manage changelogs. You should use the Slam CLI to add a new changelog entry, otherwise
+Pydoc-Markdown uses [Slap][] to manage changelogs. You should use the Slap CLI to add a new changelog entry, otherwise
 you need to manually generate a UUID-4.
 
     $ slap changelog add -t <type> -d <changelog message> [--issue <issue_url>]

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,9 +16,11 @@ If you want to talk about a potential contribution before investing any time, pl
 
 ## Changelog entries
 
-Pydoc-Markdown uses [Slam][] to manage changelogs. You should use the Slam CLI to add a new changelog entry, otherwise
+Pydoc-Markdown uses [Slap][] to manage changelogs. You should use the Slam CLI to add a new changelog entry, otherwise
 you need to manually generate a UUID-4.
 
     $ slap changelog add -t <type> -d <changelog message> [--issue <issue_url>]
 
 After you create the pull request, GitHub Actions will take care of injecting the PR URL into the changelog entry.
+
+For a full list of accepted changelog types see [here](https://niklasrosenstein.github.io/slap/commands/changelog/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["documentation", "docs", "generator", "markdown", "pydoc"]
 Homepage = "https://github.com/NiklasRosenstein/pydoc-markdown"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 click = ">=7.1,<9.0"
 "databind.core" = "^4.3.0"
 "databind.json" = "^4.3.0"
@@ -83,6 +83,7 @@ hugo = "pydoc_markdown.contrib.renderers.hugo:HugoRenderer"
 markdown = "pydoc_markdown.contrib.renderers.markdown:MarkdownRenderer"
 mkdocs = "pydoc_markdown.contrib.renderers.mkdocs:MkdocsRenderer"
 docusaurus = "pydoc_markdown.contrib.renderers.docusaurus:DocusaurusRenderer"
+nextra = "pydoc_markdown.contrib.renderers.nextra:NextraRenderer"
 jinja2 = "pydoc_markdown.contrib.renderers.jinja2:Jinja2Renderer"
 
 [tool.poetry.plugins."pydoc_markdown.interfaces.SourceLinker"]

--- a/src/pydoc_markdown/contrib/renderers/docusaurus.py
+++ b/src/pydoc_markdown/contrib/renderers/docusaurus.py
@@ -122,7 +122,6 @@ class DocusaurusRenderer(Renderer):
             "label": self.sidebar_top_level_label,
         }
         self._build_sidebar_tree(sidebar, module_tree)
-        breakpoint()
         if sidebar.get("items"):
             if self.sidebar_top_level_module_label:
                 sidebar["items"][0]["label"] = self.sidebar_top_level_module_label

--- a/src/pydoc_markdown/contrib/renderers/nextra.py
+++ b/src/pydoc_markdown/contrib/renderers/nextra.py
@@ -34,16 +34,11 @@ class CustomizedMarkdownRenderer(MarkdownRenderer):
 
 
 @dataclasses.dataclass
-class DocusaurusRenderer(Renderer):
+class NextraRenderer(Renderer):
     """
-    Produces Markdown files and a `sidebar.json` file for use in a [Docusaurus v2][1] websites.
+    Produces Markdown files for use in a Nextra docs website.
     It creates files in a fixed layout that reflects the structure of the documented packages.
     The files will be rendered into the directory specified with the #docs_base_path option.
-
-    Check out the complete [Docusaurus example on GitHub][2].
-
-    [1]: https://v2.docusaurus.io/
-    [2]: https://github.com/NiklasRosenstein/pydoc-markdown/tree/develop/examples/docusaurus
 
     ### Options
     """
@@ -53,12 +48,12 @@ class DocusaurusRenderer(Renderer):
         default_factory=CustomizedMarkdownRenderer
     )
 
-    #: The path where the docusaurus docs content is. Defaults "docs" folder.
+    #: The path where the Nextra docs content is. Defaults "docs" folder.
     docs_base_path: str = "docs"
 
     #: The output path inside the docs_base_path folder, used to output the
     #: module reference.
-    relative_output_path: str = "reference"
+    relative_output_path: str = "pages"
 
     #: The sidebar path inside the docs_base_path folder, used to output the
     #: sidebar for the module reference.
@@ -109,59 +104,3 @@ class DocusaurusRenderer(Renderer):
             # only update the relative module tree if the file is not empty
             relative_module_tree["edges"].append(os.path.splitext(str(filepath.relative_to(self.docs_base_path)))[0])
 
-        self._render_side_bar_config(module_tree)
-
-    def _render_side_bar_config(self, module_tree: t.Dict[t.Text, t.Any]) -> None:
-        """
-        Render sidebar configuration in a JSON file. See Docusaurus sidebar structure:
-
-        https://v2.docusaurus.io/docs/docs-introduction/#sidebar
-        """
-        sidebar: t.Dict[str, t.Any] = {
-            "type": "category",
-            "label": self.sidebar_top_level_label,
-        }
-        self._build_sidebar_tree(sidebar, module_tree)
-        breakpoint()
-        if sidebar.get("items"):
-            if self.sidebar_top_level_module_label:
-                sidebar["items"][0]["label"] = self.sidebar_top_level_module_label
-
-            if not self.sidebar_top_level_label:
-                # it needs to be a dictionary, not a list; this assumes that
-                # there is only one top-level module
-                sidebar = sidebar["items"][0]
-
-        sidebar_path = Path(self.docs_base_path) / self.relative_output_path / self.relative_sidebar_path
-        with sidebar_path.open("w") as handle:
-            logger.info("Render file %s", sidebar_path)
-            json.dump(sidebar, handle, indent=2, sort_keys=True)
-
-    def _build_sidebar_tree(self, sidebar: t.Dict[t.Text, t.Any], module_tree: t.Dict[t.Text, t.Any]) -> None:
-        """
-        Recursively build the sidebar tree, it follows Docusaurus sidebar structure:
-
-        https://v2.docusaurus.io/docs/docs-introduction/#sidebar
-        """
-        sidebar["items"] = module_tree.get("edges", [])
-        if os.name == "nt":
-            # Make generated configuration more portable across operating systems (see #129).
-            sidebar["items"] = [x.replace("\\", "/") for x in sidebar["items"]]
-        for child_name, child_tree in module_tree.get("children", {}).items():
-            child = {
-                "type": "category",
-                "label": child_name,
-            }
-            self._build_sidebar_tree(child, child_tree)
-            sidebar["items"].append(child)
-
-        def _sort_items(item: t.Union[t.Text, t.Dict[t.Text, t.Any]]) -> t.Tuple[int, t.Text]:
-            """Sort sidebar items. Order follows:
-            1. modules containing items come first
-            2. alphanumeric order is applied
-            """
-            is_edge = int(isinstance(item, str))
-            label = item if is_edge else item.get("label")  # type: ignore
-            return is_edge, str(label)
-
-        sidebar["items"] = sorted(sidebar["items"], key=_sort_items)

--- a/src/pydoc_markdown/contrib/renderers/nextra.py
+++ b/src/pydoc_markdown/contrib/renderers/nextra.py
@@ -32,6 +32,9 @@ class CustomizedMarkdownRenderer(MarkdownRenderer):
         "---\n" "sidebar_label: {relative_module_name}\n" "title: {module_name}\n" "---\n\n"
     )
 
+    add_module_prefix: bool = False
+    use_fixed_header_levels: bool = False
+
 
 @dataclasses.dataclass
 class NextraRenderer(Renderer):

--- a/src/pydoc_markdown/main.py
+++ b/src/pydoc_markdown/main.py
@@ -330,6 +330,7 @@ def cli(
                 "mkdocs": static.DEFAULT_MKDOCS_CONFIG,
                 "hugo": static.DEFAULT_HUGO_CONFIG,
                 "docusaurus": static.DEFAULT_DOCUSAURUS_CONFIG,
+                "nextra": static.DEFAULT_NEXTRA_CONFIG
             }
             with open(filename, "w") as fp:
                 fp.write(source[bootstrap])

--- a/src/pydoc_markdown/static.py
+++ b/src/pydoc_markdown/static.py
@@ -84,6 +84,7 @@ renderer:
           contents: [ my_project, my_project.* ]
 """.lstrip()
 
+#: Default configuration for Docusaurus to use Pydoc-Markdown.
 DEFAULT_DOCUSAURUS_CONFIG = """
 loaders:
   - type: python
@@ -98,6 +99,21 @@ renderer:
   relative_output_path: reference
   relative_sidebar_path: sidebar.json
   sidebar_top_level_label: 'Reference'
+""".lstrip()
+
+#: Default configuration for Nextra to use Pydoc-Markdown.
+DEFAULT_NEXTRA_CONFIG = """
+loaders:
+  - type: python
+processors:
+  - type: filter
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: nextra
+  docs_base_path: docs
+  relative_output_path: pages
 """.lstrip()
 
 


### PR DESCRIPTION
This PR adds support for the [Nextra Docs Theme](https://nextra.site/docs/docs-theme) to pydocs-markdown. The basic site structure is similar to docusaurus so I've reused the docusaurus renderer without the `sidebar.json`.

## Changelog
I've attempted to add a changelog entry in accordance with the [contribution-guidelines](https://github.com/NiklasRosenstein/pydoc-markdown/blob/develop/.github/CONTRIBUTING.md) however, after installing `slap-cli` with pipx I received an error

```python
slap changelog add -t changelog -d "Adds Nextra support"

> invalid change type: changelog
```

I eventually realized the issue was with the type flag so I've included updates to the contributing markdown with references to the acceptable set of types and a typo fix.

## Slap

I'm going to add these comments here since it looks like you're also the author of Slap but it looks like slaps docs build might have failed pulling in the readme from the project root see [here](https://niklasrosenstein.github.io/slap/).