### PR TITLE
nr/fix pre post render key aliases

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,6 +3,7 @@ id = "e7dfe5ac-5b5d-41fe-9b6c-433c5045ec89"
 type = "fix"
 description = "Fix key aliases for `pre-render` and `post-render` keys in `Hooks` configuration"
 author = "@NiklasRosenstein"
+pr = "https://github.com/NiklasRosenstein/pydoc-markdown/pull/295"
 issues = [
     "https://github.com/NiklasRosenstein/pydoc-markdown/issues/291",
 ]

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,8 @@
+[[entries]]
+id = "e7dfe5ac-5b5d-41fe-9b6c-433c5045ec89"
+type = "fix"
+description = "Fix key aliases for `pre-render` and `post-render` keys in `Hooks` configuration"
+author = "@NiklasRosenstein"
+issues = [
+    "https://github.com/NiklasRosenstein/pydoc-markdown/issues/291",
+]

--- a/src/pydoc_markdown/__init__.py
+++ b/src/pydoc_markdown/__init__.py
@@ -29,12 +29,13 @@ import logging
 import os
 import subprocess
 import typing as t
+import typing_extensions as te
 from pathlib import Path
 
 import databind.json
 import docspec
 import tomli
-from databind.core import Context as DatabindContext, ExtraKeys, Location, format_context_trace
+from databind.core import Alias, Context as DatabindContext, ExtraKeys, format_context_trace
 
 from pydoc_markdown.contrib.loaders.python import PythonLoader
 from pydoc_markdown.contrib.processors.crossref import CrossrefProcessor
@@ -52,8 +53,8 @@ logger = logging.getLogger(__name__)
 
 @dataclasses.dataclass
 class Hooks:
-    pre_render: t.List[str] = dataclasses.field(default_factory=list, metadata={"alias": "pre-render"})
-    post_render: t.List[str] = dataclasses.field(default_factory=list, metadata={"alias": "post-render"})
+    pre_render: te.Annotated[t.List[str], Alias("pre-render")] = dataclasses.field(default_factory=list)
+    post_render: te.Annotated[t.List[str], Alias("post-render")] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass

--- a/src/pydoc_markdown/__init__.py
+++ b/src/pydoc_markdown/__init__.py
@@ -29,12 +29,12 @@ import logging
 import os
 import subprocess
 import typing as t
-import typing_extensions as te
 from pathlib import Path
 
 import databind.json
 import docspec
 import tomli
+import typing_extensions as te
 from databind.core import Alias, Context as DatabindContext, ExtraKeys, format_context_trace
 
 from pydoc_markdown.contrib.loaders.python import PythonLoader

--- a/test/test_yaml_config.py
+++ b/test/test_yaml_config.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 
 from pytest import raises
 
-from pydoc_markdown import PydocMarkdown
+from pydoc_markdown import Hooks, PydocMarkdown
 from pydoc_markdown.contrib.renderers.docusaurus import CustomizedMarkdownRenderer, DocusaurusRenderer
 from pydoc_markdown.contrib.renderers.hugo import HugoConfig, HugoRenderer
 from pydoc_markdown.contrib.renderers.markdown import MarkdownRenderer
@@ -133,3 +133,17 @@ def test__PydocMarkdown__load_config__catch_unknown_keys() -> None:
         "  ^: TypeHint(pydoc_markdown.contrib.renderers.markdown.MarkdownRenderer)",
         "Unknown key(s) \"{'renderfoo'}\" at:\n  $: TypeHint(pydoc_markdown.PydocMarkdown)",
     ]
+
+
+def test__PydocMarkdown__load_config__can_deserialize_pre_post_render_hooks() -> None:
+    pydoc_markdown = PydocMarkdown()
+    pydoc_markdown.load_config(
+        {
+            "hooks": {
+                "pre-render": ["echo foo"],
+                "post-render": ["echo bar"],
+            }
+        }
+    )
+
+    assert pydoc_markdown.hooks == Hooks(["echo foo"], ["echo bar"])


### PR DESCRIPTION
- fix: Fix key aliases for `pre-render` and `post-render` keys in `Hooks` configuration
- add Unit tests for deserializing pre-render and post-render hooks
