### PR TITLE
Adding unify to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ pull request to add your project to this list!
 * [haystack by deepset](https://docs.haystack.deepset.ai/reference/agent-api)
 * [tensorchord/envd](https://envd.tensorchord.ai/api/starlark/v0/config.html)
 * [tqdm](https://tqdm.github.io/)
+* [unify](https://unify.ai)


### PR DESCRIPTION
I'm from [Unify](https://unify.ai), we're currently using `pydoc-markdown` for building our python client documentation