### PR TITLE
Fix --server

### DIFF
--- a/src/pydoc_markdown/util/watchdog.py
+++ b/src/pydoc_markdown/util/watchdog.py
@@ -57,7 +57,7 @@ def watch_paths(paths: List[str], recursive: bool = False) -> Tuple[BaseObserver
     observer = Observer()
 
     for directory in directories:
-        observer.schedule(event_handler, directory, recursive)
+        observer.schedule(event_handler, directory, recursive=recursive)
     observer.start()
 
     return observer, event


### PR DESCRIPTION
```py
  File "lib/python3.13/site-packages/pydoc_markdown/util/watchdog.py", line 60, in watch_paths
    observer.schedule(event_handler, directory, recursive)
TypeError: BaseObserver.schedule() takes 3 positional arguments but 4 were given
```