### PR TITLE
Add page titles and deterministic module discovery

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -53,3 +53,9 @@ type = "breaking change"
 description = "Raise the minimum supported Python version to 3.10."
 author = "rosensteinniklas@gmail.com"
 pr = "https://github.com/NiklasRosenstein/pydoc-markdown/pull/355"
+
+[[entries]]
+id = "b211059d-51aa-4a41-b7af-bbbdec84bd67"
+type = "feature"
+description = "Allow setting a fallback page title for standalone Markdown rendering."
+author = "rosensteinniklas@gmail.com"

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -59,9 +59,11 @@ id = "b211059d-51aa-4a41-b7af-bbbdec84bd67"
 type = "feature"
 description = "Allow setting a fallback page title for standalone Markdown rendering."
 author = "rosensteinniklas@gmail.com"
+pr = "https://github.com/NiklasRosenstein/pydoc-markdown/pull/356"
 
 [[entries]]
 id = "89d0181f-c678-427b-81c9-6c0171f24cc9"
 type = "improvement"
 description = "Make automatically discovered module ordering deterministic."
 author = "rosensteinniklas@gmail.com"
+pr = "https://github.com/NiklasRosenstein/pydoc-markdown/pull/356"

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -59,3 +59,9 @@ id = "b211059d-51aa-4a41-b7af-bbbdec84bd67"
 type = "feature"
 description = "Allow setting a fallback page title for standalone Markdown rendering."
 author = "rosensteinniklas@gmail.com"
+
+[[entries]]
+id = "89d0181f-c678-427b-81c9-6c0171f24cc9"
+type = "improvement"
+description = "Make automatically discovered module ordering deterministic."
+author = "rosensteinniklas@gmail.com"

--- a/docs/content/usage/cli-and-api.md
+++ b/docs/content/usage/cli-and-api.md
@@ -23,7 +23,7 @@ pydoc-markdown -m my_module '{
       type: markdown,
       descriptive_class_title: false,
       render_page_title: true,
-      page_title: API Documentation,
+      page_title: "API Documentation",
       render_toc: true
     }
   }' > my_module.md

--- a/docs/content/usage/cli-and-api.md
+++ b/docs/content/usage/cli-and-api.md
@@ -22,6 +22,8 @@ pydoc-markdown -m my_module '{
     renderer: {
       type: markdown,
       descriptive_class_title: false,
+      render_page_title: true,
+      page_title: API Documentation,
       render_toc: true
     }
   }' > my_module.md

--- a/src/pydoc_markdown/contrib/loaders/python.py
+++ b/src/pydoc_markdown/contrib/loaders/python.py
@@ -105,6 +105,7 @@ class PythonLoader(Loader):
         modules = list(self.modules or [])
         packages = list(self.packages or [])
         do_discover = self.modules is None and self.packages is None
+        files: t.List[t.Tuple[str, str]] = []
 
         if do_discover:
             for path in search_path:
@@ -125,6 +126,7 @@ class PythonLoader(Loader):
                         continue
                     if isinstance(item, docspec_python.DiscoveryResult.Module):
                         modules.append(item.name)
+                        files.append((item.name, item.filename))
                     elif isinstance(item, docspec_python.DiscoveryResult.Package):
                         packages.append(item.name)
 
@@ -136,16 +138,26 @@ class PythonLoader(Loader):
             do_discover,
         )
 
-        loaded_modules = docspec_python.load_python_modules(
+        if do_discover:
+            def load_discovered_modules() -> t.Iterator[docspec.Module]:
+                for package in packages:
+                    files.extend(docspec_python.iter_package_files(package, search_path))
+                files.sort(key=lambda item: item[0])
+                yield from docspec_python.load_python_modules(
+                    files=files,
+                    options=self.parser,
+                    encoding=self.encoding,
+                )
+
+            return load_discovered_modules()
+
+        return docspec_python.load_python_modules(
             modules=modules,
             packages=packages,
             search_path=search_path,
             options=self.parser,
             encoding=self.encoding,
         )
-        if do_discover:
-            return sorted(loaded_modules, key=lambda module: module.name)
-        return loaded_modules
 
     # PluginBase
 

--- a/src/pydoc_markdown/contrib/loaders/python.py
+++ b/src/pydoc_markdown/contrib/loaders/python.py
@@ -139,6 +139,7 @@ class PythonLoader(Loader):
         )
 
         if do_discover:
+
             def load_discovered_modules() -> t.Iterator[docspec.Module]:
                 for package in packages:
                     files.extend(docspec_python.iter_package_files(package, search_path))

--- a/src/pydoc_markdown/contrib/loaders/python.py
+++ b/src/pydoc_markdown/contrib/loaders/python.py
@@ -45,7 +45,8 @@ class PythonLoader(Loader):
     loaded and how to configure the parser.
 
     With no #modules or #packages set, the #PythonLoader will discover available modules
-    in the current and `src/` directory.
+    in the current and `src/` directory. Automatically discovered modules are returned
+    in name order; explicitly configured modules and packages retain their configured order.
 
     __lib2to3 Quirks__
 
@@ -135,13 +136,16 @@ class PythonLoader(Loader):
             do_discover,
         )
 
-        return docspec_python.load_python_modules(
+        loaded_modules = docspec_python.load_python_modules(
             modules=modules,
             packages=packages,
             search_path=search_path,
             options=self.parser,
             encoding=self.encoding,
         )
+        if do_discover:
+            return sorted(loaded_modules, key=lambda module: module.name)
+        return loaded_modules
 
     # PluginBase
 

--- a/src/pydoc_markdown/contrib/renderers/markdown.py
+++ b/src/pydoc_markdown/contrib/renderers/markdown.py
@@ -222,6 +222,10 @@ class MarkdownRenderer(Renderer, SinglePageRenderer, SingleObjectRenderer):
     #: a file relative to the context directory (usually the working directory).
     format_code_style: str = "pep8"
 
+    #: The title of the page when one is not supplied by a parent renderer and
+    #: #render_page_title is enabled.
+    page_title: t.Optional[str] = None
+
     def __post_init__(self) -> None:
         self._resolver = MarkdownReferenceResolver()
 
@@ -447,6 +451,9 @@ class MarkdownRenderer(Renderer, SinglePageRenderer, SingleObjectRenderer):
     def render_single_page(
         self, fp: t.TextIO, modules: t.List[docspec.Module], page_title: t.Optional[str] = None
     ) -> None:
+        if page_title is None:
+            page_title = self.page_title
+
         if self.render_page_title:
             fp.write("# {}\n\n".format(page_title))
 

--- a/src/pydoc_markdown/contrib/renderers/markdown.py
+++ b/src/pydoc_markdown/contrib/renderers/markdown.py
@@ -455,6 +455,10 @@ class MarkdownRenderer(Renderer, SinglePageRenderer, SingleObjectRenderer):
             page_title = self.page_title
 
         if self.render_page_title:
+            if page_title is None:
+                raise ValueError(
+                    "page_title is required when render_page_title is enabled (set MarkdownRenderer.page_title or pass page_title)."
+                )
             fp.write("# {}\n\n".format(page_title))
 
         if self.render_toc:

--- a/test/renderers/test_markdown.py
+++ b/test/renderers/test_markdown.py
@@ -78,3 +78,21 @@ def test_markdown_renderer(filename: str) -> None:
     config.processor.process(modules, None)
     result = config.renderer.render_to_string(modules)
     assert_text_equals(result, case.output)
+
+
+def test_markdown_renderer_page_title_fallback() -> None:
+    renderer = databind.json.load(
+        {"render_page_title": True, "page_title": "API Documentation"},
+        MarkdownRenderer,
+    )
+
+    assert renderer.render_to_string([]) == "# API Documentation\n\n"
+
+
+def test_markdown_renderer_explicit_page_title_takes_precedence() -> None:
+    renderer = MarkdownRenderer(render_page_title=True, page_title="API Documentation")
+    fp = io.StringIO()
+
+    renderer.render_single_page(fp, [], "Specific Page")
+
+    assert fp.getvalue() == "# Specific Page\n\n"

--- a/test/test_python_loader.py
+++ b/test/test_python_loader.py
@@ -12,12 +12,40 @@ def init_loader(loader: PythonLoader, directory: str) -> PythonLoader:
 
 
 def test_automatic_discovery_sorts_loaded_modules_by_exact_name(monkeypatch, tmp_path) -> None:
-    modules = [types.SimpleNamespace(name="alpha"), types.SimpleNamespace(name="Beta")]
-    monkeypatch.setattr(docspec_python, "discover", lambda path: iter(()))
-    monkeypatch.setattr(docspec_python, "load_python_modules", lambda **kwargs: iter(modules))
-    loader = init_loader(PythonLoader(search_path=["."]), str(tmp_path))
+    discovered = [
+        docspec_python.DiscoveryResult.Module("alpha", "alpha.py"),
+        docspec_python.DiscoveryResult.Package("package", "package"),
+        docspec_python.DiscoveryResult.Module("Beta", "Beta.py"),
+    ]
+    expanded_package = False
+    consumed = False
 
-    assert [module.name for module in loader.load()] == ["Beta", "alpha"]
+    def iter_package_files(package, search_path):
+        nonlocal expanded_package
+        expanded_package = True
+        yield "package.z", "package/z.py"
+        yield "package", "package/__init__.py"
+        yield "package.a", "package/a.py"
+
+    def load_python_modules(**kwargs):
+        def generate():
+            nonlocal consumed
+            consumed = True
+            yield from (types.SimpleNamespace(name=name) for name, _ in kwargs["files"])
+
+        return generate()
+
+    monkeypatch.setattr(docspec_python, "discover", lambda path: iter(discovered))
+    monkeypatch.setattr(docspec_python, "iter_package_files", iter_package_files)
+    monkeypatch.setattr(docspec_python, "load_python_modules", load_python_modules)
+    loader = init_loader(PythonLoader(search_path=["."]), str(tmp_path))
+    loaded_modules = loader.load()
+
+    assert expanded_package is False
+    assert consumed is False
+    assert [module.name for module in loaded_modules] == ["Beta", "alpha", "package", "package.a", "package.z"]
+    assert expanded_package is True
+    assert consumed is True
 
 
 def test_explicit_module_and_package_order_is_preserved(monkeypatch, tmp_path) -> None:
@@ -45,12 +73,19 @@ def test_explicit_module_and_package_order_is_preserved(monkeypatch, tmp_path) -
 
 def test_automatic_discovery_preserves_member_source_order(monkeypatch, tmp_path) -> None:
     members = [types.SimpleNamespace(name="z_member"), types.SimpleNamespace(name="a_member")]
-    modules = [
-        types.SimpleNamespace(name="z_module", members=[]),
-        types.SimpleNamespace(name="a_module", members=members),
+    discovered = [
+        docspec_python.DiscoveryResult.Module("z_module", "z_module.py"),
+        docspec_python.DiscoveryResult.Module("a_module", "a_module.py"),
     ]
-    monkeypatch.setattr(docspec_python, "discover", lambda path: iter(()))
-    monkeypatch.setattr(docspec_python, "load_python_modules", lambda **kwargs: iter(modules))
+
+    def load_python_modules(**kwargs):
+        return iter(
+            types.SimpleNamespace(name=name, members=members if name == "a_module" else [])
+            for name, _ in kwargs["files"]
+        )
+
+    monkeypatch.setattr(docspec_python, "discover", lambda path: iter(discovered))
+    monkeypatch.setattr(docspec_python, "load_python_modules", load_python_modules)
     loader = init_loader(PythonLoader(search_path=["."]), str(tmp_path))
 
     loaded_modules = list(loader.load())

--- a/test/test_python_loader.py
+++ b/test/test_python_loader.py
@@ -1,0 +1,59 @@
+import types
+
+import docspec_python
+
+from pydoc_markdown.contrib.loaders.python import PythonLoader
+from pydoc_markdown.interfaces import Context
+
+
+def init_loader(loader: PythonLoader, directory: str) -> PythonLoader:
+    loader.init(Context(directory))
+    return loader
+
+
+def test_automatic_discovery_sorts_loaded_modules_by_exact_name(monkeypatch, tmp_path) -> None:
+    modules = [types.SimpleNamespace(name="alpha"), types.SimpleNamespace(name="Beta")]
+    monkeypatch.setattr(docspec_python, "discover", lambda path: iter(()))
+    monkeypatch.setattr(docspec_python, "load_python_modules", lambda **kwargs: iter(modules))
+    loader = init_loader(PythonLoader(search_path=["."]), str(tmp_path))
+
+    assert [module.name for module in loader.load()] == ["Beta", "alpha"]
+
+
+def test_explicit_module_and_package_order_is_preserved(monkeypatch, tmp_path) -> None:
+    captured = {}
+
+    def load_python_modules(**kwargs):
+        captured.update(kwargs)
+        names = [*kwargs["modules"], *kwargs["packages"]]
+        return iter(types.SimpleNamespace(name=name) for name in names)
+
+    monkeypatch.setattr(docspec_python, "load_python_modules", load_python_modules)
+    loader = init_loader(
+        PythonLoader(
+            search_path=["."],
+            modules=["z_module", "a_module"],
+            packages=["z_package", "a_package"],
+        ),
+        str(tmp_path),
+    )
+
+    assert [module.name for module in loader.load()] == ["z_module", "a_module", "z_package", "a_package"]
+    assert captured["modules"] == ["z_module", "a_module"]
+    assert captured["packages"] == ["z_package", "a_package"]
+
+
+def test_automatic_discovery_preserves_member_source_order(monkeypatch, tmp_path) -> None:
+    members = [types.SimpleNamespace(name="z_member"), types.SimpleNamespace(name="a_member")]
+    modules = [
+        types.SimpleNamespace(name="z_module", members=[]),
+        types.SimpleNamespace(name="a_module", members=members),
+    ]
+    monkeypatch.setattr(docspec_python, "discover", lambda path: iter(()))
+    monkeypatch.setattr(docspec_python, "load_python_modules", lambda **kwargs: iter(modules))
+    loader = init_loader(PythonLoader(search_path=["."]), str(tmp_path))
+
+    loaded_modules = list(loader.load())
+
+    assert [module.name for module in loaded_modules] == ["a_module", "z_module"]
+    assert [member.name for member in loaded_modules[0].members] == ["z_member", "a_member"]


### PR DESCRIPTION
## Summary

- add a configurable `MarkdownRenderer.page_title` fallback for standalone rendering while keeping explicit page titles authoritative
- sort the final module list by exact name only during automatic Python discovery
- preserve explicitly configured module/package order and API member source order
- document both behaviors and add focused regression coverage

Closes #307
Closes #340

## Design notes

The discovery fix belongs in `PythonLoader`, so every renderer receives deterministic input. Sorting happens after loading because nested package traversal is also nondeterministic; sorting only `docspec_python.discover()` results would not cover nested modules. Explicit `modules` and `packages` retain their configured order.

No code from #342 is reused: its renderer-level default recursively reordered API members and contained a TOC indentation regression.

## Validation

- full pytest suite: 80 passed
- mypy: 31 source files passed
- Ruff lint and format checks passed
- Poetry metadata validation passed with pre-existing deprecation warnings only
- independent review found no blocking issues

`ROADMAP.md` remains local-only and is not part of this PR.
