### PR TITLE
Optionally fence doctest examples

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -105,7 +105,7 @@ issues = [
 [[entries]]
 id = "ca3903fb-3f4e-45b2-873a-337d65ab8d50"
 type = "feature"
-description = "Optionally render doctest blocks from Example sections as fenced Python Markdown."
+description = "Render doctest prompt blocks as collision-safe fenced Python Markdown, with an opt-out."
 author = "rosensteinniklas@gmail.com"
 issues = [
     "https://github.com/NiklasRosenstein/pydoc-markdown/issues/327",

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -101,3 +101,12 @@ pr = "https://github.com/NiklasRosenstein/pydoc-markdown/pull/360"
 issues = [
     "https://github.com/NiklasRosenstein/pydoc-markdown/issues/259",
 ]
+
+[[entries]]
+id = "ca3903fb-3f4e-45b2-873a-337d65ab8d50"
+type = "feature"
+description = "Optionally render doctest blocks from Example sections as fenced Python Markdown."
+author = "rosensteinniklas@gmail.com"
+issues = [
+    "https://github.com/NiklasRosenstein/pydoc-markdown/issues/327",
+]

--- a/docs/content/usage/yaml.md
+++ b/docs/content/usage/yaml.md
@@ -134,6 +134,21 @@ processors:
 
 The default `smart` processor also detects NumPy-style docstrings automatically.
 
+Doctest prompts in `Example` and `Examples` sections can optionally be rendered as fenced Python code blocks. The
+option is disabled by default and does not rewrite doctest-looking text outside those sections. Enable it for both
+formats used by the `smart` processor as follows:
+
+```yaml
+processors:
+- type: filter
+- type: smart
+  google:
+    render_doctest_examples: true
+  sphinx:
+    render_doctest_examples: true
+- type: crossref
+```
+
 ## Renderer
 
 The `$.renderer` defines the renderer to use when running `pydoc-markdown` without arguments.

--- a/docs/content/usage/yaml.md
+++ b/docs/content/usage/yaml.md
@@ -134,18 +134,21 @@ processors:
 
 The default `smart` processor also detects NumPy-style docstrings automatically.
 
-Doctest prompts in `Example` and `Examples` sections can optionally be rendered as fenced Python code blocks. The
-option is disabled by default and does not rewrite doctest-looking text outside those sections. Enable it for both
-formats used by the `smart` processor as follows:
+Doctest prompt blocks are rendered as fenced Python code by default wherever they occur in a processed docstring.
+Existing Markdown fences are preserved, and generated fences expand when necessary so doctest output cannot close
+them accidentally. To keep doctest blocks unchanged, disable the behavior for both formats used by the `smart`
+processor:
 
 ```yaml
 processors:
 - type: filter
 - type: smart
   google:
-    render_doctest_examples: true
+    render_doctest_blocks: false
+  pydocmd:
+    render_doctest_blocks: false
   sphinx:
-    render_doctest_examples: true
+    render_doctest_blocks: false
 - type: crossref
 ```
 

--- a/src/pydoc_markdown/contrib/processors/google.py
+++ b/src/pydoc_markdown/contrib/processors/google.py
@@ -26,6 +26,8 @@ import typing as t
 import docspec
 
 from pydoc_markdown.contrib.processors.sphinx import (
+    _active_container_indent,
+    _leading_width,
     fence_doctest_blocks,
     generate_sections_markdown,
     get_markdown_fence_opener,
@@ -80,9 +82,8 @@ class GoogleProcessor(Processor):
     @doc:fmt:google
     """
 
-    #: Wrap doctest blocks from Example and Examples sections in Python Markdown fences.
-    #: Disabled by default so that upgrading does not rewrite existing documentation.
-    render_doctest_examples: bool = False
+    #: Wrap doctest prompt blocks in collision-safe Python Markdown fences.
+    render_doctest_blocks: bool = True
 
     _param_res = [
         re.compile(r"^(?P<param>\S+):\s+(?P<desc>.+)$"),
@@ -131,29 +132,32 @@ class GoogleProcessor(Processor):
         if not node.docstring:
             return
 
+        content = node.docstring.content
+        if self.render_doctest_blocks:
+            content = fence_doctest_blocks(content)
+
         lines = []
         current_lines: t.List[str] = []
-        markdown_fence: t.Optional[t.Tuple[str, int]] = None
+        markdown_fence: t.Optional[t.Tuple[str, int, int]] = None
         keyword = None
 
         def _commit():
             if keyword:
-                section_lines = current_lines
-                if self.render_doctest_examples and keyword in ("Example", "Examples"):
-                    section_lines = fence_doctest_blocks("\n".join(section_lines)).split("\n")
-                generate_sections_markdown(lines, {keyword: section_lines})
+                generate_sections_markdown(lines, {keyword: current_lines})
             else:
                 lines.extend(current_lines)
             current_lines.clear()
 
-        for line in node.docstring.content.split("\n"):
+        content_lines = content.split("\n")
+        for index, line in enumerate(content_lines):
             if markdown_fence is not None:
                 current_lines.append(line)
                 if is_markdown_fence_closer(line, markdown_fence):
                     markdown_fence = None
                 continue
 
-            markdown_fence = get_markdown_fence_opener(line)
+            container_indent = _active_container_indent(content_lines[:index], "", _leading_width(line))
+            markdown_fence = get_markdown_fence_opener(line, container_indent or (4 if keyword else 0))
             if markdown_fence is not None:
                 current_lines.append(line)
                 continue
@@ -166,10 +170,6 @@ class GoogleProcessor(Processor):
 
             if keyword is None:
                 lines.append(line)
-                continue
-
-            if self.render_doctest_examples and keyword in ("Example", "Examples"):
-                current_lines.append(line)
                 continue
 
             for param_re in self._param_res:

--- a/src/pydoc_markdown/contrib/processors/google.py
+++ b/src/pydoc_markdown/contrib/processors/google.py
@@ -25,7 +25,12 @@ import typing as t
 
 import docspec
 
-from pydoc_markdown.contrib.processors.sphinx import generate_sections_markdown
+from pydoc_markdown.contrib.processors.sphinx import (
+    fence_doctest_blocks,
+    generate_sections_markdown,
+    get_markdown_fence_opener,
+    is_markdown_fence_closer,
+)
 from pydoc_markdown.interfaces import Processor, Resolver
 
 
@@ -74,6 +79,10 @@ class GoogleProcessor(Processor):
 
     @doc:fmt:google
     """
+
+    #: Wrap doctest blocks from Example and Examples sections in Python Markdown fences.
+    #: Disabled by default so that upgrading does not rewrite existing documentation.
+    render_doctest_examples: bool = False
 
     _param_res = [
         re.compile(r"^(?P<param>\S+):\s+(?P<desc>.+)$"),
@@ -124,23 +133,28 @@ class GoogleProcessor(Processor):
 
         lines = []
         current_lines: t.List[str] = []
-        in_codeblock = False
+        markdown_fence: t.Optional[t.Tuple[str, int]] = None
         keyword = None
 
         def _commit():
             if keyword:
-                generate_sections_markdown(lines, {keyword: current_lines})
+                section_lines = current_lines
+                if self.render_doctest_examples and keyword in ("Example", "Examples"):
+                    section_lines = fence_doctest_blocks("\n".join(section_lines)).split("\n")
+                generate_sections_markdown(lines, {keyword: section_lines})
             else:
                 lines.extend(current_lines)
             current_lines.clear()
 
         for line in node.docstring.content.split("\n"):
-            if line.lstrip().startswith("```"):
-                in_codeblock = not in_codeblock
+            if markdown_fence is not None:
                 current_lines.append(line)
+                if is_markdown_fence_closer(line, markdown_fence):
+                    markdown_fence = None
                 continue
 
-            if in_codeblock:
+            markdown_fence = get_markdown_fence_opener(line)
+            if markdown_fence is not None:
                 current_lines.append(line)
                 continue
 
@@ -152,6 +166,10 @@ class GoogleProcessor(Processor):
 
             if keyword is None:
                 lines.append(line)
+                continue
+
+            if self.render_doctest_examples and keyword in ("Example", "Examples"):
+                current_lines.append(line)
                 continue
 
             for param_re in self._param_res:

--- a/src/pydoc_markdown/contrib/processors/pydocmd.py
+++ b/src/pydoc_markdown/contrib/processors/pydocmd.py
@@ -25,6 +25,14 @@ import typing as t
 
 import docspec
 
+from pydoc_markdown.contrib.processors.sphinx import (
+    _active_container_indent,
+    _leading_width,
+    _split_blockquote_prefix,
+    fence_doctest_blocks,
+    get_markdown_fence_opener,
+    is_markdown_fence_closer,
+)
 from pydoc_markdown.interfaces import Processor, Resolver
 
 # TODO @NiklasRosenstein Figure out a way to mark text linking to other
@@ -70,20 +78,55 @@ class PydocmdProcessor(Processor):
     @doc:fmt:pydocmd
     """
 
+    #: Wrap doctest prompt blocks in collision-safe Python Markdown fences.
+    render_doctest_blocks: bool = True
+
     def process(self, modules: t.List[docspec.Module], resolver: t.Optional[Resolver]) -> None:
         docspec.visit(modules, self._process)
 
     def _process(self, node: docspec.ApiObject):
         if not node.docstring:
             return
+        content = node.docstring.content
+        if self.render_doctest_blocks:
+            content = fence_doctest_blocks(content)
         lines = []
-        codeblock_opened = False
+        markdown_fence: t.Optional[t.Tuple[str, int, int]] = None
+        markdown_fence_quote_depth = 0
+        markdown_fence_container_indent = 0
         current_section = None
-        for line in node.docstring.content.split("\n"):
-            if line.startswith("```"):
-                codeblock_opened = not codeblock_opened
-            if not codeblock_opened:
-                line, current_section = self._preprocess_line(line, current_section)
+        content_lines = content.split("\n")
+        for index, line in enumerate(content_lines):
+            quote_prefix, unquoted_line = _split_blockquote_prefix(line)
+            if markdown_fence is not None:
+                quote_depth = quote_prefix.count(">")
+                stripped = unquoted_line.lstrip()
+                container_ended = (markdown_fence_quote_depth and quote_depth < markdown_fence_quote_depth) or (
+                    markdown_fence_container_indent
+                    and stripped
+                    and _leading_width(unquoted_line) < markdown_fence_container_indent
+                )
+                if container_ended:
+                    markdown_fence = None
+                else:
+                    lines.append(line)
+                    if quote_depth == markdown_fence_quote_depth and is_markdown_fence_closer(
+                        unquoted_line, markdown_fence
+                    ):
+                        markdown_fence = None
+                    continue
+
+            container_indent = _active_container_indent(
+                content_lines[:index], quote_prefix, _leading_width(unquoted_line)
+            )
+            markdown_fence = get_markdown_fence_opener(unquoted_line, container_indent)
+            if markdown_fence is not None:
+                markdown_fence_quote_depth = quote_prefix.count(">")
+                markdown_fence_container_indent = container_indent
+                lines.append(line)
+                continue
+
+            line, current_section = self._preprocess_line(line, current_section)
             lines.append(line)
         node.docstring.content = "\n".join(lines)
 

--- a/src/pydoc_markdown/contrib/processors/sphinx.py
+++ b/src/pydoc_markdown/contrib/processors/sphinx.py
@@ -60,71 +60,262 @@ def _markdown_list_item(value: str) -> str:
 
 
 _MARKDOWN_FENCE_RE = re.compile(r"^(?P<fence>`{3,}|~{3,})(?P<info>.*)$")
+_MARKDOWN_CONTAINER_RE = re.compile(r"^(?:[ \t]*(?:[-+*]|\d{1,9}[.)])|[ \t]*(?:!!!|\?\?\?))[ \t]+")
+_MARKDOWN_SECTION_RE = re.compile(r"^[ \t]*\S.*:[ \t]*$")
 
 
-def get_markdown_fence_opener(line: str) -> t.Optional[t.Tuple[str, int]]:
+def _leading_width(line: str) -> int:
+    whitespace = line[: len(line) - len(line.lstrip())]
+    return len(whitespace.expandtabs(4))
+
+
+def _split_blockquote_prefix(line: str, container_indent: int = 0) -> t.Tuple[str, str]:
+    offset = 0
+    column = 0
+    while offset < len(line) and column < container_indent and line[offset] in " \t":
+        if line[offset] == " ":
+            column += 1
+        else:
+            column += 4 - column % 4
+        offset += 1
+    if column < container_indent:
+        offset = 0
+    found_quote = False
+    while True:
+        marker = offset
+        spaces = 0
+        while marker < len(line) and line[marker] == " " and spaces < 3:
+            marker += 1
+            spaces += 1
+        if line.startswith(">>>", marker):
+            return (line[:offset], line[offset:]) if found_quote else ("", line)
+        if marker >= len(line) or line[marker] != ">":
+            return (line[:offset], line[offset:]) if found_quote else ("", line)
+        found_quote = True
+        offset = marker + 1
+        if offset < len(line) and line[offset] in " \t":
+            offset += 1
+
+
+def _active_container_indent(lines: t.Iterable[str], quote_prefix: str, current_indent: int) -> int:
+    """Returns the content indentation of the active list or admonition container."""
+
+    minimum_child_indent = current_indent
+    for previous in reversed(list(lines)):
+        if not previous.strip():
+            continue
+        previous_quote_prefix, previous_content = _split_blockquote_prefix(previous)
+        if previous_quote_prefix != quote_prefix:
+            break
+        match = _MARKDOWN_CONTAINER_RE.match(previous_content)
+        if match:
+            content_indent = len(match.group().expandtabs(4))
+            if content_indent <= current_indent and minimum_child_indent >= content_indent:
+                return content_indent
+        elif _MARKDOWN_SECTION_RE.match(previous_content):
+            content_indent = _leading_width(previous_content) + 4
+            if content_indent <= current_indent and minimum_child_indent >= content_indent:
+                return content_indent
+        minimum_child_indent = min(minimum_child_indent, _leading_width(previous_content))
+    return 0
+
+
+def get_markdown_fence_opener(line: str, container_indent: int = 0) -> t.Optional[t.Tuple[str, int, int]]:
     """Return the character and length of a Markdown fence opener, if any."""
 
+    opener_indent = _leading_width(line)
+    if opener_indent > container_indent + 3:
+        return None
     match = _MARKDOWN_FENCE_RE.match(line.lstrip())
     if not match:
         return None
     fence = match.group("fence")
     if fence[0] == "`" and "`" in match.group("info"):
         return None
-    return fence[0], len(fence)
+    return fence[0], len(fence), container_indent
 
 
-def is_markdown_fence_closer(line: str, fence: t.Tuple[str, int]) -> bool:
+def is_markdown_fence_closer(line: str, fence: t.Tuple[str, int, int]) -> bool:
     """Return whether *line* closes the Markdown fence described by *fence*."""
 
-    character, minimum_length = fence
+    character, minimum_length, container_indent = fence
+    if _leading_width(line) > container_indent + 3:
+        return False
     stripped = line.strip()
     return len(stripped) >= minimum_length and all(value == character for value in stripped)
 
 
-def fence_doctest_blocks(text: str) -> str:
+def fence_doctest_blocks(text: str, replacement: t.Optional[t.Callable[[str], str]] = None) -> str:
     """Wrap doctest blocks in a Python Markdown fence.
 
-    The caller is responsible for limiting *text* to an Example or Examples section. A block starts
-    with a ``>>>`` prompt and ends at the next blank line. Existing Markdown fences are preserved.
+    A block starts with a ``>>>`` prompt and ends at the next blank line. Existing Markdown fences
+    are preserved, and generated fences are long enough not to collide with the block's contents.
     """
 
     lines: t.List[str] = []
-    in_doctest = False
-    markdown_fence: t.Optional[t.Tuple[str, int]] = None
+    doctest_lines: t.List[str] = []
+    doctest_indent = 0
+    doctest_prefix = ""
+    doctest_source_prefix = ""
+    doctest_quote_prefix = ""
+    markdown_fence: t.Optional[t.Tuple[str, int, int]] = None
+    markdown_fence_quote_depth = 0
+    markdown_fence_container_indent = 0
+
+    def flush_doctest() -> None:
+        if not doctest_lines:
+            return
+        longest_run = max(
+            (len(match.group()) for line in doctest_lines for match in re.finditer(r"`+", line)), default=0
+        )
+        fence = "`" * max(3, longest_run + 1)
+        rendered = "\n".join(
+            [
+                doctest_prefix + fence + "python",
+                *(doctest_prefix + line for line in doctest_lines),
+                doctest_prefix + fence,
+            ]
+        )
+        if replacement:
+            lines.append(doctest_source_prefix + replacement(rendered))
+        else:
+            lines.extend(rendered.split("\n"))
+        doctest_lines.clear()
 
     for line in text.split("\n"):
-        stripped = line.lstrip()
+        structural_indent = _active_container_indent(lines, "", _leading_width(line))
+        quote_prefix, unquoted_line = _split_blockquote_prefix(line, structural_indent)
+        stripped = unquoted_line.lstrip()
 
-        if in_doctest:
-            if not stripped:
-                lines.extend(["```", line])
-                in_doctest = False
+        if doctest_lines:
+            if quote_prefix != doctest_quote_prefix:
+                flush_doctest()
+            elif not stripped:
+                flush_doctest()
+                lines.append(line)
+                continue
+            leading_length = len(unquoted_line) - len(stripped)
+            if quote_prefix == doctest_quote_prefix and leading_length >= doctest_indent:
+                doctest_lines.append(unquoted_line[min(doctest_indent, leading_length) :])
+                continue
+            if doctest_lines:
+                flush_doctest()
+
+        if markdown_fence is not None:
+            quote_depth = quote_prefix.count(">")
+            container_ended = (markdown_fence_quote_depth and quote_depth < markdown_fence_quote_depth) or (
+                markdown_fence_container_indent
+                and stripped
+                and _leading_width(unquoted_line) < markdown_fence_container_indent
+            )
+            if container_ended:
+                markdown_fence = None
             else:
                 lines.append(line)
-            continue
+                if quote_depth == markdown_fence_quote_depth and is_markdown_fence_closer(
+                    unquoted_line, markdown_fence
+                ):
+                    markdown_fence = None
+                continue
 
+        container_indent = _active_container_indent(lines, quote_prefix, _leading_width(unquoted_line))
+        markdown_fence = get_markdown_fence_opener(unquoted_line, container_indent)
         if markdown_fence is not None:
-            lines.append(line)
-            if is_markdown_fence_closer(line, markdown_fence):
-                markdown_fence = None
-            continue
-
-        markdown_fence = get_markdown_fence_opener(line)
-        if markdown_fence is not None:
+            markdown_fence_quote_depth = quote_prefix.count(">")
+            markdown_fence_container_indent = container_indent
             lines.append(line)
             continue
 
         if re.match(r"^>>>($|\s)", stripped):
-            lines.extend(["```python", stripped])
-            in_doctest = True
+            doctest_indent = len(unquoted_line) - len(stripped)
+            doctest_quote_prefix = quote_prefix
+            doctest_source_prefix = quote_prefix + unquoted_line[:doctest_indent]
+            doctest_prefix = quote_prefix
+            for previous in reversed(lines):
+                if not previous.strip():
+                    continue
+                _, previous_content = _split_blockquote_prefix(previous)
+                if _leading_width(previous_content) >= doctest_indent:
+                    continue
+                if re.match(r"^\s*(?:[-+*]|\d{1,9}[.)])(?:[ \t]+|$)", previous_content) or re.match(
+                    r"^\s*(?:!!!|\?\?\?)(?:[ \t]+|$)", previous_content
+                ):
+                    doctest_prefix += unquoted_line[:doctest_indent]
+                break
+            doctest_lines.append(stripped)
         else:
             lines.append(line)
 
-    if in_doctest:
-        lines.append("```")
+    flush_doctest()
 
     return "\n".join(lines)
+
+
+def _protect_doctest_blocks(text: str) -> t.Tuple[str, t.Dict[str, str]]:
+    replacements: t.Dict[str, str] = {}
+
+    def replace(block: str) -> str:
+        index = len(replacements)
+        token = "__PYDOC_MARKDOWN_DOCTEST_BLOCK_{}__".format(index)
+        while token in text or token in replacements or any(token in value for value in replacements.values()):
+            index += 1
+            token = "__PYDOC_MARKDOWN_DOCTEST_BLOCK_{}__".format(index)
+        replacements[token] = block
+        return token
+
+    return fence_doctest_blocks(text, replace), replacements
+
+
+def _restore_doctest_blocks(content: str, replacements: t.Dict[str, str]) -> str:
+    """Restore protected doctests, keeping embedded field descriptions valid Markdown."""
+
+    def preceding_container_indent(offset: int) -> int:
+        minimum_child_indent: t.Optional[int] = None
+        previous_content = content[:offset].rstrip("\r\n")
+        for previous_line in reversed(previous_content.splitlines()):
+            if not previous_line.strip():
+                continue
+            marker = _MARKDOWN_CONTAINER_RE.match(previous_line)
+            if marker:
+                container_indent = len(marker.group().expandtabs(4))
+                if minimum_child_indent is None or minimum_child_indent >= container_indent:
+                    return container_indent
+            line_indent = _leading_width(previous_line)
+            if line_indent == 0:
+                return 0
+            minimum_child_indent = (
+                line_indent if minimum_child_indent is None else min(minimum_child_indent, line_indent)
+            )
+        return 0
+
+    for token, block in replacements.items():
+        standalone_pattern = r"(?m)^[ \t]*(?:>[ \t]?)*[ \t]*{}[ \t]*$".format(re.escape(token))
+
+        def restore_standalone(match: t.Match[str]) -> str:
+            container_indent = preceding_container_indent(match.start())
+            if not container_indent:
+                return block
+            indent = " " * container_indent
+            indented_block = "\n".join(indent + line for line in block.splitlines())
+            return "\n" + indented_block
+
+        content, count = re.subn(standalone_pattern, restore_standalone, content)
+        if count:
+            continue
+
+        embedded_pattern = r"(?m)^(?P<prefix>[^\r\n]*\S)[ \t]*{}[ \t]*$".format(re.escape(token))
+
+        def restore_embedded(match: t.Match[str]) -> str:
+            prefix = match.group("prefix").rstrip()
+            marker = _MARKDOWN_CONTAINER_RE.match(prefix)
+            indent = " " * (len(marker.group().expandtabs(4)) if marker else _leading_width(prefix))
+            indented_block = "\n".join(indent + line for line in block.splitlines())
+            return prefix + "\n\n" + indented_block
+
+        content, count = re.subn(embedded_pattern, restore_embedded, content)
+        if not count:
+            content = content.replace(token, block)
+    return content
 
 
 @dataclasses.dataclass
@@ -153,9 +344,8 @@ class SphinxProcessor(Processor):
 
     style: docstring_parser.DocstringStyle = docstring_parser.DocstringStyle.AUTO
 
-    #: Wrap doctest blocks from Example and Examples sections in Python Markdown fences.
-    #: Disabled by default so that upgrading does not rewrite existing documentation.
-    render_doctest_examples: bool = False
+    #: Wrap doctest prompt blocks in collision-safe Python Markdown fences.
+    render_doctest_blocks: bool = True
 
     _KEYWORDS = {
         "Arguments": [
@@ -279,16 +469,6 @@ class SphinxProcessor(Processor):
                 converted[heading] = [_markdown_list_item(entry) for entry in entries]
         return converted
 
-    def _convert_examples(self, examples: t.List[docstring_parser.common.DocstringExample]) -> t.List[str]:
-        chunks = []
-        for example in examples:
-            chunk = example.description or ""
-            if example.snippet:
-                chunk = example.snippet + ("\n" + chunk if chunk else "")
-            if chunk:
-                chunks.append(fence_doctest_blocks(chunk))
-        return "\n".join(chunks).split("\n") if chunks else []
-
     def _process(self, node: docspec.ApiObject) -> None:
         if not node.docstring:
             return
@@ -296,8 +476,12 @@ class SphinxProcessor(Processor):
         lines = []
         components: t.Dict[str, t.List[str]] = {}
 
-        parsed_docstring = docstring_parser.parse(node.docstring.content, self.style)
-        self._restore_rest_description_indentation(node.docstring.content, parsed_docstring)
+        content = node.docstring.content
+        protected_doctests: t.Dict[str, str] = {}
+        if self.render_doctest_blocks:
+            content, protected_doctests = _protect_doctest_blocks(content)
+        parsed_docstring = docstring_parser.parse(content, self.style)
+        self._restore_rest_description_indentation(content, parsed_docstring)
         attribute_params = [
             entry
             for entry in parsed_docstring.params
@@ -334,8 +518,6 @@ class SphinxProcessor(Processor):
                 ]
             else:
                 components[heading] = entries
-        if self.render_doctest_examples:
-            components["Examples"] = self._convert_examples(parsed_docstring.examples)
 
         if parsed_docstring.short_description:
             lines.append(parsed_docstring.short_description)
@@ -345,7 +527,7 @@ class SphinxProcessor(Processor):
             lines.append("")
 
         generate_sections_markdown(lines, components)
-        node.docstring.content = "\n".join(lines)
+        node.docstring.content = _restore_doctest_blocks("\n".join(lines), protected_doctests)
 
     @staticmethod
     def _restore_rest_description_indentation(text: str, parsed_docstring: docstring_parser.Docstring) -> None:

--- a/src/pydoc_markdown/contrib/processors/sphinx.py
+++ b/src/pydoc_markdown/contrib/processors/sphinx.py
@@ -59,6 +59,74 @@ def _markdown_list_item(value: str) -> str:
     return "- " + value.replace("\n", "\n  ")
 
 
+_MARKDOWN_FENCE_RE = re.compile(r"^(?P<fence>`{3,}|~{3,})(?P<info>.*)$")
+
+
+def get_markdown_fence_opener(line: str) -> t.Optional[t.Tuple[str, int]]:
+    """Return the character and length of a Markdown fence opener, if any."""
+
+    match = _MARKDOWN_FENCE_RE.match(line.lstrip())
+    if not match:
+        return None
+    fence = match.group("fence")
+    if fence[0] == "`" and "`" in match.group("info"):
+        return None
+    return fence[0], len(fence)
+
+
+def is_markdown_fence_closer(line: str, fence: t.Tuple[str, int]) -> bool:
+    """Return whether *line* closes the Markdown fence described by *fence*."""
+
+    character, minimum_length = fence
+    stripped = line.strip()
+    return len(stripped) >= minimum_length and all(value == character for value in stripped)
+
+
+def fence_doctest_blocks(text: str) -> str:
+    """Wrap doctest blocks in a Python Markdown fence.
+
+    The caller is responsible for limiting *text* to an Example or Examples section. A block starts
+    with a ``>>>`` prompt and ends at the next blank line. Existing Markdown fences are preserved.
+    """
+
+    lines: t.List[str] = []
+    in_doctest = False
+    markdown_fence: t.Optional[t.Tuple[str, int]] = None
+
+    for line in text.split("\n"):
+        stripped = line.lstrip()
+
+        if in_doctest:
+            if not stripped:
+                lines.extend(["```", line])
+                in_doctest = False
+            else:
+                lines.append(line)
+            continue
+
+        if markdown_fence is not None:
+            lines.append(line)
+            if is_markdown_fence_closer(line, markdown_fence):
+                markdown_fence = None
+            continue
+
+        markdown_fence = get_markdown_fence_opener(line)
+        if markdown_fence is not None:
+            lines.append(line)
+            continue
+
+        if re.match(r"^>>>($|\s)", stripped):
+            lines.extend(["```python", stripped])
+            in_doctest = True
+        else:
+            lines.append(line)
+
+    if in_doctest:
+        lines.append("```")
+
+    return "\n".join(lines)
+
+
 @dataclasses.dataclass
 class SphinxProcessor(Processor):
     """
@@ -84,6 +152,10 @@ class SphinxProcessor(Processor):
     """
 
     style: docstring_parser.DocstringStyle = docstring_parser.DocstringStyle.AUTO
+
+    #: Wrap doctest blocks from Example and Examples sections in Python Markdown fences.
+    #: Disabled by default so that upgrading does not rewrite existing documentation.
+    render_doctest_examples: bool = False
 
     _KEYWORDS = {
         "Arguments": [
@@ -207,6 +279,16 @@ class SphinxProcessor(Processor):
                 converted[heading] = [_markdown_list_item(entry) for entry in entries]
         return converted
 
+    def _convert_examples(self, examples: t.List[docstring_parser.common.DocstringExample]) -> t.List[str]:
+        chunks = []
+        for example in examples:
+            chunk = example.description or ""
+            if example.snippet:
+                chunk = example.snippet + ("\n" + chunk if chunk else "")
+            if chunk:
+                chunks.append(fence_doctest_blocks(chunk))
+        return "\n".join(chunks).split("\n") if chunks else []
+
     def _process(self, node: docspec.ApiObject) -> None:
         if not node.docstring:
             return
@@ -252,6 +334,8 @@ class SphinxProcessor(Processor):
                 ]
             else:
                 components[heading] = entries
+        if self.render_doctest_examples:
+            components["Examples"] = self._convert_examples(parsed_docstring.examples)
 
         if parsed_docstring.short_description:
             lines.append(parsed_docstring.short_description)

--- a/test/processors/test_doctest_examples.py
+++ b/test/processors/test_doctest_examples.py
@@ -1,0 +1,231 @@
+import pytest
+from docstring_parser import DocstringStyle
+
+from pydoc_markdown.contrib.processors.google import GoogleProcessor
+from pydoc_markdown.contrib.processors.sphinx import SphinxProcessor
+
+from . import assert_processor_result
+
+
+@pytest.mark.parametrize("heading", ["Example", "Examples"])
+def test_google_doctest_examples(heading: str) -> None:
+    assert_processor_result(
+        GoogleProcessor(render_doctest_examples=True),
+        f"""
+        Summary.
+
+        {heading}:
+            Introductory prose.
+
+            >>> add(
+            ...     1,
+            ...     2,
+            ... )
+            3
+
+            Between the blocks.
+
+            >>> greet()
+            hello
+
+            Closing prose.
+        """,
+        f"""
+        Summary.
+
+        **{heading}**:
+
+        Introductory prose.
+
+        ```python
+        >>> add(
+        ...     1,
+        ...     2,
+        ... )
+        3
+        ```
+
+        Between the blocks.
+
+        ```python
+        >>> greet()
+        hello
+        ```
+
+        Closing prose.
+        """,
+    )
+
+
+def test_numpy_doctest_examples() -> None:
+    assert_processor_result(
+        SphinxProcessor(style=DocstringStyle.NUMPYDOC, render_doctest_examples=True),
+        """
+        Summary.
+
+        Examples
+        --------
+        Introductory prose.
+
+        >>> add(
+        ...     1,
+        ...     2,
+        ... )
+        3
+
+        Between the blocks.
+
+        >>> greet()
+        hello
+
+        Closing prose.
+        """,
+        """
+        Summary.
+
+        **Examples**:
+
+        Introductory prose.
+
+        ```python
+        >>> add(
+        ...     1,
+        ...     2,
+        ... )
+        3
+        ```
+
+        Between the blocks.
+
+        ```python
+        >>> greet()
+        hello
+        ```
+
+        Closing prose.
+        """,
+    )
+
+
+def test_google_doctest_examples_preserve_dictionary_output() -> None:
+    assert_processor_result(
+        GoogleProcessor(render_doctest_examples=True),
+        """
+        Examples:
+            >>> {"answer": 42}
+            {'answer': 42}
+        """,
+        """
+        **Examples**:
+
+        ```python
+        >>> {"answer": 42}
+        {'answer': 42}
+        ```
+        """,
+    )
+
+
+def test_doctest_examples_are_disabled_by_default() -> None:
+    assert_processor_result(
+        GoogleProcessor(),
+        """
+        Examples:
+            >>> add(1, 2)
+            3
+        """,
+        """
+        **Examples**:
+
+          >>> add(1, 2)
+          3
+        """,
+    )
+
+
+def test_doctest_text_outside_examples_is_not_rewritten() -> None:
+    assert_processor_result(
+        GoogleProcessor(render_doctest_examples=True),
+        """
+        >>> outside_examples()
+        prose mentioning >>> is not a prompt
+
+        Notes:
+            >>> also_outside_examples()
+        Examples:
+            prose mentioning >>> is still not a prompt
+        """,
+        """
+        >>> outside_examples()
+        prose mentioning >>> is not a prompt
+
+        **Notes**:
+
+          >>> also_outside_examples()
+
+        **Examples**:
+
+        prose mentioning >>> is still not a prompt
+        """,
+    )
+
+
+def test_existing_fence_inside_examples_is_not_rewritten() -> None:
+    assert_processor_result(
+        GoogleProcessor(render_doctest_examples=True),
+        """
+        Examples:
+            ```text
+            >>> already_fenced()
+            ```
+        """,
+        """
+        **Examples**:
+
+            ```text
+            >>> already_fenced()
+            ```
+        """,
+    )
+
+
+def test_existing_tilde_fence_inside_examples_is_not_rewritten() -> None:
+    assert_processor_result(
+        GoogleProcessor(render_doctest_examples=True),
+        """
+        Examples:
+            ~~~python
+            >>> already_fenced()
+            ~~~
+        """,
+        """
+        **Examples**:
+
+            ~~~python
+            >>> already_fenced()
+            ~~~
+        """,
+    )
+
+
+def test_longer_fence_is_not_closed_by_shorter_fence_inside_it() -> None:
+    assert_processor_result(
+        GoogleProcessor(render_doctest_examples=True),
+        """
+        Examples:
+            ````text
+            ```
+            >>> already_fenced()
+            ```
+            ````
+        """,
+        """
+        **Examples**:
+
+            ````text
+            ```
+            >>> already_fenced()
+            ```
+            ````
+        """,
+    )

--- a/test/processors/test_doctest_examples.py
+++ b/test/processors/test_doctest_examples.py
@@ -2,7 +2,9 @@ import pytest
 from docstring_parser import DocstringStyle
 
 from pydoc_markdown.contrib.processors.google import GoogleProcessor
-from pydoc_markdown.contrib.processors.sphinx import SphinxProcessor
+from pydoc_markdown.contrib.processors.pydocmd import PydocmdProcessor
+from pydoc_markdown.contrib.processors.smart import SmartProcessor
+from pydoc_markdown.contrib.processors.sphinx import SphinxProcessor, fence_doctest_blocks
 
 from . import assert_processor_result
 
@@ -10,7 +12,7 @@ from . import assert_processor_result
 @pytest.mark.parametrize("heading", ["Example", "Examples"])
 def test_google_doctest_examples(heading: str) -> None:
     assert_processor_result(
-        GoogleProcessor(render_doctest_examples=True),
+        GoogleProcessor(),
         f"""
         Summary.
 
@@ -35,7 +37,7 @@ def test_google_doctest_examples(heading: str) -> None:
 
         **{heading}**:
 
-        Introductory prose.
+          Introductory prose.
 
         ```python
         >>> add(
@@ -45,21 +47,21 @@ def test_google_doctest_examples(heading: str) -> None:
         3
         ```
 
-        Between the blocks.
+          Between the blocks.
 
         ```python
         >>> greet()
         hello
         ```
 
-        Closing prose.
+          Closing prose.
         """,
     )
 
 
 def test_numpy_doctest_examples() -> None:
     assert_processor_result(
-        SphinxProcessor(style=DocstringStyle.NUMPYDOC, render_doctest_examples=True),
+        SphinxProcessor(style=DocstringStyle.NUMPYDOC),
         """
         Summary.
 
@@ -109,7 +111,7 @@ def test_numpy_doctest_examples() -> None:
 
 def test_google_doctest_examples_preserve_dictionary_output() -> None:
     assert_processor_result(
-        GoogleProcessor(render_doctest_examples=True),
+        GoogleProcessor(),
         """
         Examples:
             >>> {"answer": 42}
@@ -126,9 +128,9 @@ def test_google_doctest_examples_preserve_dictionary_output() -> None:
     )
 
 
-def test_doctest_examples_are_disabled_by_default() -> None:
+def test_doctest_blocks_can_be_disabled() -> None:
     assert_processor_result(
-        GoogleProcessor(),
+        GoogleProcessor(render_doctest_blocks=False),
         """
         Examples:
             >>> add(1, 2)
@@ -143,9 +145,9 @@ def test_doctest_examples_are_disabled_by_default() -> None:
     )
 
 
-def test_doctest_text_outside_examples_is_not_rewritten() -> None:
+def test_doctest_text_outside_examples_is_rewritten() -> None:
     assert_processor_result(
-        GoogleProcessor(render_doctest_examples=True),
+        GoogleProcessor(),
         """
         >>> outside_examples()
         prose mentioning >>> is not a prompt
@@ -156,23 +158,27 @@ def test_doctest_text_outside_examples_is_not_rewritten() -> None:
             prose mentioning >>> is still not a prompt
         """,
         """
+        ```python
         >>> outside_examples()
         prose mentioning >>> is not a prompt
+        ```
 
         **Notes**:
 
-          >>> also_outside_examples()
+        ```python
+        >>> also_outside_examples()
+        ```
 
         **Examples**:
 
-        prose mentioning >>> is still not a prompt
+          prose mentioning >>> is still not a prompt
         """,
     )
 
 
 def test_existing_fence_inside_examples_is_not_rewritten() -> None:
     assert_processor_result(
-        GoogleProcessor(render_doctest_examples=True),
+        GoogleProcessor(),
         """
         Examples:
             ```text
@@ -191,7 +197,7 @@ def test_existing_fence_inside_examples_is_not_rewritten() -> None:
 
 def test_existing_tilde_fence_inside_examples_is_not_rewritten() -> None:
     assert_processor_result(
-        GoogleProcessor(render_doctest_examples=True),
+        GoogleProcessor(),
         """
         Examples:
             ~~~python
@@ -210,7 +216,7 @@ def test_existing_tilde_fence_inside_examples_is_not_rewritten() -> None:
 
 def test_longer_fence_is_not_closed_by_shorter_fence_inside_it() -> None:
     assert_processor_result(
-        GoogleProcessor(render_doctest_examples=True),
+        GoogleProcessor(),
         """
         Examples:
             ````text
@@ -229,3 +235,177 @@ def test_longer_fence_is_not_closed_by_shorter_fence_inside_it() -> None:
             ````
         """,
     )
+
+
+def test_generated_fence_does_not_collide_with_doctest_output() -> None:
+    assert_processor_result(
+        GoogleProcessor(),
+        """
+        Examples:
+            >>> print("```")
+            ```
+        """,
+        """
+        **Examples**:
+
+        ````python
+        >>> print("```")
+        ```
+        ````
+        """,
+    )
+
+
+def test_pydocmd_tracks_collision_safe_fence_delimiter() -> None:
+    assert_processor_result(
+        PydocmdProcessor(),
+        '>>> print("```")\n```\n\n# Arguments\noutside: value',
+        '````python\n>>> print("```")\n```\n````\n\n__Arguments__\n\n- __outside__: value',
+    )
+
+
+def test_google_recognizes_generated_fence_nested_in_list() -> None:
+    assert_processor_result(
+        GoogleProcessor(),
+        "Examples:\n    - Case:\n        >>> example()\n        item: value",
+        "**Examples**:\n\n  - Case:\n        ```python\n        >>> example()\n        item: value\n        ```",
+    )
+
+
+def test_generated_fence_preserves_list_container_indentation() -> None:
+    assert fence_doctest_blocks("- First:\n\n    >>> example()\n    result") == (
+        "- First:\n\n    ```python\n    >>> example()\n    result\n    ```"
+    )
+
+
+def test_generated_fence_finds_list_container_before_introductory_prose() -> None:
+    assert fence_doctest_blocks("- Item:\n\n    Intro.\n\n    >>> example()\n    result") == (
+        "- Item:\n\n    Intro.\n\n    ```python\n    >>> example()\n    result\n    ```"
+    )
+
+
+def test_smart_processor_fences_plain_docstring_doctests() -> None:
+    assert_processor_result(
+        SmartProcessor(),
+        "Plain docstring.\n\n>>> example()\nresult",
+        "Plain docstring.\n\n```python\n>>> example()\nresult\n```",
+    )
+
+
+@pytest.mark.parametrize("processor", [PydocmdProcessor(), SmartProcessor()])
+def test_pydocmd_fences_doctests_before_rewriting_section_syntax(processor) -> None:
+    assert_processor_result(
+        processor,
+        ">>> example()\n# Arguments\nitem: value\n\n# Arguments\noutside: value",
+        ("```python\n>>> example()\n# Arguments\nitem: value\n```\n\n__Arguments__\n\n- __outside__: value"),
+    )
+
+
+def test_sphinx_processor_protects_field_looking_doctest_output() -> None:
+    assert_processor_result(
+        SphinxProcessor(style=DocstringStyle.REST),
+        'Example:\n\n    >>> print(":return: value")\n    :return: value\n\n:param item: An item.',
+        (
+            'Example:\n\n```python\n>>> print(":return: value")\n:return: value\n```\n\n'
+            "**Arguments**:\n\n- `item`: An item."
+        ),
+    )
+
+
+def test_sphinx_doctest_placeholder_does_not_collide_with_content() -> None:
+    assert_processor_result(
+        SphinxProcessor(style=DocstringStyle.REST),
+        "__PYDOC_MARKDOWN_DOCTEST_BLOCK_0__\n\n>>> example()\nresult",
+        "__PYDOC_MARKDOWN_DOCTEST_BLOCK_0__\n\n```python\n>>> example()\nresult\n```",
+    )
+
+
+def test_sphinx_doctest_placeholders_do_not_reuse_allocated_tokens() -> None:
+    assert_processor_result(
+        SphinxProcessor(style=DocstringStyle.REST),
+        "__PYDOC_MARKDOWN_DOCTEST_BLOCK_0__\n\n>>> first()\none\n\n>>> second()\ntwo",
+        ("__PYDOC_MARKDOWN_DOCTEST_BLOCK_0__\n\n```python\n>>> first()\none\n```\n\n```python\n>>> second()\ntwo\n```"),
+    )
+
+
+def test_sphinx_processor_restores_doctest_field_description_as_nested_block() -> None:
+    assert_processor_result(
+        SphinxProcessor(style=DocstringStyle.REST),
+        ":param item:\n    >>> example()\n    result",
+        "**Arguments**:\n\n- `item`:\n\n  ```python\n  >>> example()\n  result\n  ```",
+    )
+
+
+def test_sphinx_processor_nests_doctest_after_field_description_prose() -> None:
+    assert_processor_result(
+        SphinxProcessor(style=DocstringStyle.REST),
+        ":param item: Intro.\n\n    >>> example()\n    result",
+        "**Arguments**:\n\n- `item`: Intro.\n\n  ```python\n  >>> example()\n  result\n  ```",
+    )
+
+
+def test_sphinx_processor_nests_multiple_doctests_in_field_description() -> None:
+    assert_processor_result(
+        SphinxProcessor(style=DocstringStyle.REST),
+        ":param item:\n    >>> first()\n    one\n\n    >>> second()\n    two",
+        (
+            "**Arguments**:\n\n- `item`:\n\n  ```python\n  >>> first()\n  one\n  ```\n\n"
+            "  ```python\n  >>> second()\n  two\n  ```"
+        ),
+    )
+
+
+def test_sphinx_processor_restores_blockquoted_doctest_without_duplicate_prefix() -> None:
+    assert_processor_result(
+        SphinxProcessor(style=DocstringStyle.REST),
+        "> >>> example()\n> result",
+        "> ```python\n> >>> example()\n> result\n> ```",
+    )
+
+
+def test_top_level_indented_code_does_not_hide_later_doctest() -> None:
+    assert fence_doctest_blocks("    ```literal\n\n>>> example()\nresult") == (
+        "    ```literal\n\n```python\n>>> example()\nresult\n```"
+    )
+
+
+def test_fence_state_ends_with_its_blockquote_container() -> None:
+    text = "> ```text\n> quoted content\n```text\n>>> already_fenced()\n```"
+    assert fence_doctest_blocks(text) == text
+
+
+def test_fence_state_ends_with_its_list_container() -> None:
+    text = "- Item:\n\n    ```text\n    list content\n```text\n>>> already_fenced()\n```"
+    assert fence_doctest_blocks(text) == text
+
+
+def test_fence_indented_inside_list_remains_protected() -> None:
+    text = "- Item:\n\n    ```text\n    >>> already_fenced()\n    ```"
+    assert fence_doctest_blocks(text) == text
+
+
+def test_indented_backticks_do_not_close_top_level_fence() -> None:
+    text = "```text\n    ```\n>>> already_fenced()\n```"
+    assert fence_doctest_blocks(text) == text
+
+
+def test_closer_indentation_is_relative_to_fence_container() -> None:
+    text = "   ```text\n    ```\n   >>> already_fenced()\n   ```"
+    assert fence_doctest_blocks(text) == text
+
+
+def test_generated_fence_preserves_blockquote_prefixes() -> None:
+    assert fence_doctest_blocks("> >>> example()\n> result") == ("> ```python\n> >>> example()\n> result\n> ```")
+
+
+def test_google_doctest_detects_blockquote_after_section_indent() -> None:
+    assert_processor_result(
+        GoogleProcessor(),
+        "Examples:\n    > >>> example()\n    > result",
+        "**Examples**:\n\n  > ```python\n  > >>> example()\n  > result\n  > ```",
+    )
+
+
+def test_pydocmd_fence_state_ends_with_container() -> None:
+    text = "- Item:\n    ```text\n    content\n```text\n# Arguments\ninside: value\n```"
+    assert_processor_result(PydocmdProcessor(), text, text)

--- a/test/processors/test_sphinx.py
+++ b/test/processors/test_sphinx.py
@@ -223,8 +223,10 @@ numpy_additional_sections_markdown = """
 
   **Examples**:
 
+  ```python
   >>> list(generate())
   [1]
+  ```
 
   **Notes**:
 
@@ -244,9 +246,11 @@ four_space_indented_code_block = """
 four_space_indented_code_block_markdown = """
   Example:
 
-      >>> url = URL('https://foo.bar')
-      >>> print(url)
-      https://foo.bar
+  ```python
+  >>> url = URL('https://foo.bar')
+  >>> print(url)
+  https://foo.bar
+  ```
 
   **Arguments**:
 
@@ -420,7 +424,7 @@ def test_numpy_additional_sections_are_preserved(processor):
         (
             DocstringStyle.GOOGLE,
             "Summary.\n\nExample:\n    >>> example()",
-            "Summary.\n\n**Examples**:\n\n>>> example()",
+            "Summary.\n\n**Examples**:\n\n```python\n>>> example()\n```",
         ),
         (
             DocstringStyle.EPYDOC,

--- a/test/test_yaml_config.py
+++ b/test/test_yaml_config.py
@@ -6,6 +6,8 @@ from docstring_parser import DocstringStyle
 from pytest import raises
 
 from pydoc_markdown import Hooks, PydocMarkdown
+from pydoc_markdown.contrib.processors.google import GoogleProcessor
+from pydoc_markdown.contrib.processors.smart import SmartProcessor
 from pydoc_markdown.contrib.processors.sphinx import SphinxProcessor
 from pydoc_markdown.contrib.renderers.docusaurus import CustomizedMarkdownRenderer, DocusaurusRenderer
 from pydoc_markdown.contrib.renderers.hugo import HugoConfig, HugoRenderer
@@ -23,6 +25,27 @@ def test__PydocMarkdown__load_config__can_select_docstring_style() -> None:
         pydoc_markdown = PydocMarkdown()
         pydoc_markdown.load_config({"processors": [{"type": "sphinx", "style": name}]})
         assert pydoc_markdown.processors == [SphinxProcessor(style=style)]
+
+
+def test__PydocMarkdown__load_config__can_enable_doctest_examples() -> None:
+    pydoc_markdown = PydocMarkdown()
+    pydoc_markdown.load_config(
+        {
+            "processors": [
+                {
+                    "type": "smart",
+                    "google": {"render_doctest_examples": True},
+                    "sphinx": {"render_doctest_examples": True},
+                }
+            ]
+        }
+    )
+    assert pydoc_markdown.processors == [
+        SmartProcessor(
+            google=GoogleProcessor(render_doctest_examples=True),
+            sphinx=SphinxProcessor(render_doctest_examples=True),
+        )
+    ]
 
 
 def test__PydocMarkdown__load_config__can_deserialize_markdown_config_from_entrypoint_name() -> None:

--- a/test/test_yaml_config.py
+++ b/test/test_yaml_config.py
@@ -7,6 +7,7 @@ from pytest import raises
 
 from pydoc_markdown import Hooks, PydocMarkdown
 from pydoc_markdown.contrib.processors.google import GoogleProcessor
+from pydoc_markdown.contrib.processors.pydocmd import PydocmdProcessor
 from pydoc_markdown.contrib.processors.smart import SmartProcessor
 from pydoc_markdown.contrib.processors.sphinx import SphinxProcessor
 from pydoc_markdown.contrib.renderers.docusaurus import CustomizedMarkdownRenderer, DocusaurusRenderer
@@ -27,23 +28,25 @@ def test__PydocMarkdown__load_config__can_select_docstring_style() -> None:
         assert pydoc_markdown.processors == [SphinxProcessor(style=style)]
 
 
-def test__PydocMarkdown__load_config__can_enable_doctest_examples() -> None:
+def test__PydocMarkdown__load_config__can_disable_doctest_blocks() -> None:
     pydoc_markdown = PydocMarkdown()
     pydoc_markdown.load_config(
         {
             "processors": [
                 {
                     "type": "smart",
-                    "google": {"render_doctest_examples": True},
-                    "sphinx": {"render_doctest_examples": True},
+                    "google": {"render_doctest_blocks": False},
+                    "pydocmd": {"render_doctest_blocks": False},
+                    "sphinx": {"render_doctest_blocks": False},
                 }
             ]
         }
     )
     assert pydoc_markdown.processors == [
         SmartProcessor(
-            google=GoogleProcessor(render_doctest_examples=True),
-            sphinx=SphinxProcessor(render_doctest_examples=True),
+            google=GoogleProcessor(render_doctest_blocks=False),
+            pydocmd=PydocmdProcessor(render_doctest_blocks=False),
+            sphinx=SphinxProcessor(render_doctest_blocks=False),
         )
     ]
 

--- a/test/testcases/renderers/markdown/codeblock_in_docstrings.txt
+++ b/test/testcases/renderers/markdown/codeblock_in_docstrings.txt
@@ -28,9 +28,11 @@ def func() -> None
 
 Example:
 
-    >>> url = URL('https://foo.bar')
-    >>> print(url)
-    https://foo.bar
+```python
+>>> url = URL('https://foo.bar')
+>>> print(url)
+https://foo.bar
+```
 
 **Arguments**:
 

--- a/test/testcases/renderers/markdown/indented_docstring_google.txt
+++ b/test/testcases/renderers/markdown/indented_docstring_google.txt
@@ -47,9 +47,11 @@ This is a docstring.
 **Example**:
 
 
-  >>> import os
-  >>> os.getenv('PYTHON')
-  'python'
+```python
+>>> import os
+>>> os.getenv('PYTHON')
+'python'
+```
 
   Or check out this code:
 

--- a/test/testcases/renderers/markdown/indented_docstring_pydocmd.txt
+++ b/test/testcases/renderers/markdown/indented_docstring_pydocmd.txt
@@ -32,9 +32,11 @@ This is a docstring.
 
 Example:
 
-    >>> import os
-    >>> os.getenv('PYTHON')
-    'python'
+```python
+>>> import os
+>>> os.getenv('PYTHON')
+'python'
+```
 
 Or check out this code:
 

--- a/test/testcases/renderers/markdown/indented_docstring_sphinx.txt
+++ b/test/testcases/renderers/markdown/indented_docstring_sphinx.txt
@@ -42,9 +42,11 @@ This is a docstring.
 None
 Example:
 
-    >>> import os
-    >>> os.getenv('PYTHON')
-    'python'
+```python
+>>> import os
+>>> os.getenv('PYTHON')
+'python'
+```
 
 Or check out this code:
 


### PR DESCRIPTION
## Summary

- add conservative opt-in doctest fencing for recognized `Example`/`Examples` sections
- support Google and NumPy/Sphinx processing, including nested Smart processor configuration
- preserve surrounding prose, multiple blocks, dictionary/colon output, and existing backtick/tilde fences
- leave doctest-looking text outside example sections and all default output unchanged
- add configuration documentation, changelog, and focused regression coverage

Closes #327.

## Stack

This PR is intentionally based on #360 because it uses docstring-parser 0.18 structured NumPy examples. It contains one separable feature commit and will be retargeted to `develop` after #360 merges.

## Validation

- Python 3.10 full suite: 110 passed
- Ruff lint and format checks pass
- canonical mypy check passes
- two review findings fixed; final re-review found no issues
- diff check passes